### PR TITLE
CLI no date given

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pip install -r requirements.txt
 
 ### Install torchtree
 ```bash
-python setup.py install
+python -m pip install .
 ```
 
 ### Check install

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
-name: treetorch
+name: torchtree
 channels:
   - pytorch
+  - bioconda
 dependencies:
   - python=3.7
   - numpy>=1.7

--- a/torchtree/cli/evolution.py
+++ b/torchtree/cli/evolution.py
@@ -537,7 +537,11 @@ def create_taxa(id_, arg):
             regex = re.compile(regex_date)
             for idx, taxon in enumerate(taxa_list):
                 res = re.search(regex, taxon['id'])
-                taxon['attributes'] = {'date': float(res.group(1))}
+                if res is not None:
+                    date = float(res.group(1))
+                else:
+                    date = 0.
+                taxon['attributes'] = {'date': date}
     return taxa
 
 


### PR DESCRIPTION
Read in fasta file with no dates given.
Assume all taxa have same dates of 0.0.
Is this sensible?

Eg a fasta file with:
```
>Alligator_mississippiensis
CCTGGTTGATCCTGC...
>Ambystoma_mexicanum
----TGGTTGATCCTG...
...
```

Also improve a couple of install steps.