### PR TITLE
Notebooks for GTR+I model inference with FluA dataset

### DIFF
--- a/notebooks/FluA_GTR_I_torchtree_api.ipynb
+++ b/notebooks/FluA_GTR_I_torchtree_api.ipynb
@@ -1,0 +1,2043 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bb589fea",
+   "metadata": {},
+   "source": [
+    "# Phylogenetic estimation using torchtree API\n",
+    "\n",
+    "> [Amine Remita](https://github.com/maremita), Department of Computer Science, Université du Québec à Montréal\n",
+    "\n",
+    "This notebook shows an example of using torchtree API to infer the branch lengths and GTR+I parameters with fixed topology.\n",
+    "\n",
+    "I really enjoyed implementing the model using torchtree. Making this notebook helped me to have a better understanding of it. So, I wanted to share my experience with you."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cb79912f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment if not included in ipython config\n",
+    "# %load_ext autoreload\n",
+    "# %autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e2d93f60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torchtree.evolution.io import read_tree_and_alignment\n",
+    "from torchtree.evolution.alignment import Alignment, Sequence\n",
+    "from torchtree.evolution.taxa import Taxa, Taxon\n",
+    "from torchtree.evolution.datatype import NucleotideDataType\n",
+    "from torchtree.evolution.site_pattern import SitePattern\n",
+    "from torchtree.evolution.site_model import InvariantSiteModel\n",
+    "from torchtree.evolution.substitution_model import GTR\n",
+    "from torchtree.evolution.tree_likelihood import TreeLikelihoodModel\n",
+    "\n",
+    "from torchtree import Parameter, TransformedParameter\n",
+    "from torchtree.evolution.tree_model import UnRootedTreeModel\n",
+    "from torchtree.distributions import Distribution\n",
+    "from torchtree.distributions.joint_distribution import JointDistributionModel\n",
+    "\n",
+    "from torchtree.variational import ELBO\n",
+    "\n",
+    "from collections import OrderedDict\n",
+    "from pprint import pprint\n",
+    "from json import dump\n",
+    "\n",
+    "import torch\n",
+    "from torch.distributions import ExpTransform, StickBreakingTransform, SigmoidTransform\n",
+    "\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "21667180",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The results of this notebook should comparable with those generated using torchtree-cli and torchtree\n",
+    "# \n",
+    "# torchtree-cli advi -m GTR -C 1 -I -i ../data/fluA.fasta -t ../data/fluA.tree > fluA_gtr_i.json\n",
+    "# torchtree fluA_gtr_i.json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "34814357",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# seed = 42\n",
+    "# torch.manual_seed(seed)\n",
+    "# np.random.seed(seed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9b6f642c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FluA dataset\n",
+    "\n",
+    "# Input files\n",
+    "newick_file = \"../data/fluA.tree\"\n",
+    "fasta_file = \"../data/fluA.fasta\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9baba0ec",
+   "metadata": {},
+   "source": [
+    "## I. Building alignment and taxa"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b0797ff4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(newick_file, 'r') as fp:\n",
+    "    newick = fp.read()\n",
+    "    newick = newick.strip()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "281d5eca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Parse fasta and tree file\n",
+    "\n",
+    "tree, dna = read_tree_and_alignment(newick_file, fasta_file, dated=True, heterochornous=True)\n",
+    "\n",
+    "sequence_list = []\n",
+    "taxa_list = []\n",
+    "\n",
+    "for taxon, seq in dna.items():\n",
+    "    sequence_list.append(Sequence(taxon.label, str(seq)))\n",
+    "    taxa_list.append(Taxon(taxon.label, None))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "d70d2210",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "135"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "taxa_id = \"taxa\"\n",
+    "\n",
+    "taxa = Taxa(taxa_id, taxa_list)\n",
+    "\n",
+    "nb_blens = len(taxa) * 2 - 3\n",
+    "nb_blens"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c7026419",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "alignment_id = \"alignment\"\n",
+    "\n",
+    "alignment = Alignment(\n",
+    "    alignment_id,              \n",
+    "    sequence_list, \n",
+    "    taxa, NucleotideDataType('nuc')\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47bc0851",
+   "metadata": {},
+   "source": [
+    "## II. Evolutionary parameters and samples holders"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cb585c41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tree_id = \"tree\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "defc17fd",
+   "metadata": {},
+   "source": [
+    "#### Initialize branch length parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "89cab55e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blens_id = f'{tree_id}.blens'\n",
+    "blens_unres_id = blens_id + '.unres'\n",
+    "\n",
+    "blens_init = 0.1\n",
+    "\n",
+    "# Parameter to hold samples of branch lengths\n",
+    "x_blens_unres = Parameter(blens_unres_id, torch.full((1, nb_blens,), np.log(blens_init)).detach())\n",
+    "\n",
+    "branch_lengths = TransformedParameter(\n",
+    "    blens_id,\n",
+    "    x_blens_unres,\n",
+    "    ExpTransform() # lower = 0\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "509013bd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'tree.blens'"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "branch_lengths.id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "5002f5df",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 135])"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x_blens_unres.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "88dd8895",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 135])"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "branch_lengths().shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "026678e2",
+   "metadata": {},
+   "source": [
+    "#### Initialize site model parameter (pinv)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b7f9ea49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "site_model_id = \"sitemodel\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "5d3342d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pinv_id = f'{site_model_id}.pinv'\n",
+    "pinv_unres_id = pinv_id + '.unres'\n",
+    "\n",
+    "pinv_init = 0.1\n",
+    "\n",
+    "# Parameter to hold samples of invariant probabilities\n",
+    "x_pinv_unres = Parameter(pinv_unres_id, torch.tensor((pinv_init,)).detach())\n",
+    "\n",
+    "pinv_param = TransformedParameter(\n",
+    "    pinv_id,\n",
+    "    x_pinv_unres,\n",
+    "    SigmoidTransform() # lower = 0, upper = 1\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "f64e6602",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'sitemodel.pinv'"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pinv_param.id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "90aea8aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "site_model = InvariantSiteModel(\n",
+    "    site_model_id,\n",
+    "    pinv_param\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d767346a",
+   "metadata": {},
+   "source": [
+    "#### Initialize GTR substitution model parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "dd4803fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subst_model_id = \"substmodel\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "dbe54b79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Rates\n",
+    "rates_id = f'{subst_model_id}.rates'\n",
+    "rates_unres_id = rates_id + '.unres'\n",
+    "\n",
+    "rates_init = 0.0\n",
+    "\n",
+    "# Parameter to hold samples of GTR substitution rates\n",
+    "x_rates_unres = Parameter(rates_unres_id, torch.full((1, 5,), rates_init).detach())\n",
+    "\n",
+    "rates_param = TransformedParameter(\n",
+    "    rates_id,\n",
+    "    x_rates_unres,\n",
+    "    StickBreakingTransform(),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "f0f5d324",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([1, 5])\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Parameter(id_='substmodel.rates.unres', tensor=torch.tensor([[0., 0., 0., 0., 0.]]))"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print(rates_param.x.shape)\n",
+    "rates_param.x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "7864f338",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([-10.7506])"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rates_param()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "ac3f2dec",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[0.1667, 0.1667, 0.1667, 0.1667, 0.1667, 0.1667]])"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rates_param.tensor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "150b7e56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Relative frequencies\n",
+    "freqs_id = f'{subst_model_id}.frequencies'\n",
+    "freqs_unres_id = freqs_id + '.unres'\n",
+    "\n",
+    "freqs_init = 0.0\n",
+    "\n",
+    "# Parameter to hold samples of GTR relative frequencies\n",
+    "x_freqs_unres = Parameter(rates_unres_id, torch.full((1, 3,), freqs_init).detach())\n",
+    "\n",
+    "freqs_param = TransformedParameter(\n",
+    "    freqs_id,\n",
+    "    x_freqs_unres,\n",
+    "    StickBreakingTransform(),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "483834b6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([-5.5452])"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "freqs_param()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "13b6edb9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[0.2500, 0.2500, 0.2500, 0.2500]])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "freqs_param.tensor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "55d34631",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subst_model = GTR(\n",
+    "    subst_model_id,\n",
+    "    rates_param,\n",
+    "    freqs_param\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "cd984ff4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[0.1667, 0.1667, 0.1667, 0.1667, 0.1667, 0.1667]])"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subst_model.rates"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4ff7277",
+   "metadata": {},
+   "source": [
+    "## III. Evolutionary joint distribution (tree likelihood + priors)\n",
+    "\n",
+    "### 1. Tree Likelihood"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d286cdc5",
+   "metadata": {},
+   "source": [
+    "#### Initialize tree model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "8ad4c755",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "tree_model = UnRootedTreeModel(\n",
+    "    tree_id,\n",
+    "    tree, \n",
+    "    taxa, \n",
+    "    branch_lengths\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26d7664c",
+   "metadata": {},
+   "source": [
+    "#### Initialize site pattern model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "87dc0df0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "site_pattern_id = \"patterns\"\n",
+    "\n",
+    "site_pattern = SitePattern(site_pattern_id, alignment)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3cbfd7e",
+   "metadata": {},
+   "source": [
+    "#### Initialize tree likelihood model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "f65411cb",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "like_id = 'like'\n",
+    "\n",
+    "tree_likelihood = TreeLikelihoodModel(\n",
+    "    id_=like_id, \n",
+    "    site_pattern=site_pattern, \n",
+    "    tree_model=tree_model, \n",
+    "    subst_model=subst_model, \n",
+    "    site_model=site_model,\n",
+    "    clock_model=None,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "2a057ab0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<torchtree.evolution.tree_model.UnRootedTreeModel at 0x7fb6401fcdc0>"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tree_model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "34c1c978",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# tree_likelihood.parameters()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "613aee5c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1])"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tree_likelihood.sample_shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "1b746323",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with torch.no_grad():\n",
+    "    tree_likelihood()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "be15b994",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[nan]])"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tree_likelihood.lp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "436f0c28",
+   "metadata": {},
+   "source": [
+    "### 2. Priors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e7ea745",
+   "metadata": {},
+   "source": [
+    "#### Branch lengths *p*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "fe0ea59a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tree.blens.prior\n",
+      "tree.blens\n"
+     ]
+    }
+   ],
+   "source": [
+    "blens_p_id = blens_id + '.prior'\n",
+    "\n",
+    "blens_prior = Distribution(\n",
+    "    blens_p_id,\n",
+    "    torch.distributions.Exponential,\n",
+    "    branch_lengths,\n",
+    "    OrderedDict({'rate': Parameter(None, torch.tensor([10.0]).detach())}),\n",
+    ")\n",
+    "\n",
+    "print(blens_prior.id)\n",
+    "print(blens_prior.x.id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7a249c7",
+   "metadata": {},
+   "source": [
+    "#### Invariant probability *p*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "0a2e8765",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sitemodel.pinv.prior\n",
+      "sitemodel.pinv\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Remark: torchtree-cli does not add a prior on pinv when using -I\n",
+    "\n",
+    "pinv_p_id = pinv_id + '.prior'\n",
+    "\n",
+    "pinv_prior = Distribution(\n",
+    "    pinv_p_id,\n",
+    "    torch.distributions.Exponential,\n",
+    "#     x_pinv_unres,\n",
+    "    pinv_param,\n",
+    "    OrderedDict({'rate': Parameter(None, torch.tensor([2.0]).detach())})\n",
+    ")\n",
+    "\n",
+    "print(pinv_prior.id)\n",
+    "print(pinv_prior.x.id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "671976e9",
+   "metadata": {},
+   "source": [
+    "#### GTR rates *p*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "91b9ab1b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "substmodel.rates.rates.prior\n",
+      "substmodel.rates\n"
+     ]
+    }
+   ],
+   "source": [
+    "rates_p_id = rates_id + '.rates.prior'\n",
+    "\n",
+    "rates_prior = Distribution(\n",
+    "    rates_p_id,\n",
+    "    torch.distributions.Dirichlet,\n",
+    "#     x_rates_unres,\n",
+    "    rates_param,\n",
+    "    OrderedDict({'concentration': Parameter(None, torch.ones(6).detach())})\n",
+    ")\n",
+    "\n",
+    "print(rates_prior.id)\n",
+    "print(rates_prior.x.id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9c94ea5",
+   "metadata": {},
+   "source": [
+    "#### GTR Frequencies *p*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "58da1928",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "substmodel.frequencies.prior\n",
+      "substmodel.frequencies\n"
+     ]
+    }
+   ],
+   "source": [
+    "freqs_p_id = freqs_id + '.prior'\n",
+    "\n",
+    "freqs_prior = Distribution(\n",
+    "    freqs_p_id,\n",
+    "    torch.distributions.Dirichlet,\n",
+    "#     x_freqs_unres,\n",
+    "    freqs_param,\n",
+    "    OrderedDict({'concentration': Parameter(None, torch.ones(4).detach())})\n",
+    ")\n",
+    "\n",
+    "print(freqs_prior.id)\n",
+    "print(freqs_prior.x.id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "4f777cd3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tree.blens.prior\n",
+      "sitemodel.pinv.prior\n",
+      "substmodel.rates.rates.prior\n",
+      "substmodel.frequencies.prior\n"
+     ]
+    }
+   ],
+   "source": [
+    "prior_joint_list = [blens_prior, pinv_prior, rates_prior, freqs_prior]\n",
+    "\n",
+    "for dist in prior_joint_list:\n",
+    "    print(dist.id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13e93ed9",
+   "metadata": {},
+   "source": [
+    "### 3. Evolutionary joint distribution *P*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "865e01b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "joint_list = [tree_likelihood] + prior_joint_list\n",
+    "\n",
+    "joint_dist = JointDistributionModel('joint', joint_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "f914b93c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "like\n",
+      "tree.blens.prior\n",
+      "sitemodel.pinv.prior\n",
+      "substmodel.rates.rates.prior\n",
+      "substmodel.frequencies.prior\n"
+     ]
+    }
+   ],
+   "source": [
+    "for model in joint_dist._distributions.models():\n",
+    "    # _distributions attribute is a core.container.Container\n",
+    "    print(model.id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "9e88d00c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with torch.no_grad():\n",
+    "    joint_dist()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae5b9091",
+   "metadata": {},
+   "source": [
+    "## IV. Variational meanfield distribution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82bd3504",
+   "metadata": {},
+   "source": [
+    "### 1. Variational independent distributions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "3e526681",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var_dist = \"Normal\"\n",
+    "var_id = \"var\" + \".\" + var_dist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "ec74ef36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var_parameters = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "26a0215d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_loc_logscale_normal(v):\n",
+    "    \n",
+    "    if isinstance(v, (int, float)):\n",
+    "        v = np.array(v)\n",
+    "    elif isinstance(v, torch.Tensor):\n",
+    "        v  = v.numpy()\n",
+    "\n",
+    "    loc = np.log(v / np.sqrt(1 + 0.001 / v**2)).tolist()\n",
+    "    scale_log = np.log(np.sqrt(np.log(1 + 0.001 / v**2))).tolist()\n",
+    "    \n",
+    "    return loc, scale_log"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d0d79e1",
+   "metadata": {},
+   "source": [
+    "#### Branch lengths *q*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "951ceaba",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-2.3502401828962083\n",
+      "-1.1753093277566469\n",
+      "\n",
+      "var.Normal.tree.blens.unres\n",
+      "tree.blens.unres\n"
+     ]
+    }
+   ],
+   "source": [
+    "## q() Branch lengths\n",
+    "b = np.array(0.1)\n",
+    "b_loc, b_scale_log = get_loc_logscale_normal(b)\n",
+    "\n",
+    "\n",
+    "# Parameters of variational distribution\n",
+    "\n",
+    "b_unres_loc = Parameter(blens_unres_id+\".loc\", \n",
+    "                torch.full((nb_blens,), b_loc))\n",
+    "\n",
+    "b_unres_scale = TransformedParameter(\n",
+    "    blens_unres_id+\".scale\",\n",
+    "    Parameter(blens_unres_id+\".scale.unres\", \n",
+    "              torch.full((nb_blens,), b_scale_log)),\n",
+    "    ExpTransform()\n",
+    ")\n",
+    "\n",
+    "var_parameters.append(b_unres_loc)\n",
+    "var_parameters.append(b_unres_scale)\n",
+    "\n",
+    "blens_q = Distribution(\n",
+    "    var_id + \".\" + blens_unres_id,\n",
+    "    torch.distributions.Normal,\n",
+    "    x_blens_unres,\n",
+    "    OrderedDict({'loc': b_unres_loc, 'scale': b_unres_scale})\n",
+    ")\n",
+    "\n",
+    "\n",
+    "print(b_loc)\n",
+    "print(b_scale_log)\n",
+    "print()\n",
+    "print(blens_q.id)\n",
+    "print(blens_q.x.id)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "5a9ed65a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# blens_q.parameters()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "f1fdf948",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with torch.no_grad():\n",
+    "    blens_q.rsample([100])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "94cef03f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([100, 135])"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "blens_q.x.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "a3def1f7",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([-2.0237, -2.4660, -2.4146, -1.7869, -2.3419, -2.2407, -2.6596, -2.8978,\n",
+       "        -2.4016, -2.5741, -2.2607, -3.0991, -2.5679, -2.3381, -2.2194, -2.4720,\n",
+       "        -2.3597, -2.3949, -2.6676, -2.4295, -2.6130, -2.9177, -2.5750, -2.3864,\n",
+       "        -2.5243, -2.2456, -2.2272, -2.4884, -2.1980, -2.5346, -2.8250, -2.5847,\n",
+       "        -2.4022, -3.1242, -2.4724, -2.4796, -2.3231, -1.8745, -2.2846, -2.1611,\n",
+       "        -2.5171, -1.9773, -2.1952, -2.6862, -2.2720, -1.8243, -2.3279, -2.0839,\n",
+       "        -2.6234, -2.5094, -2.6803, -2.4260, -2.0064, -2.4540, -2.4428, -2.3874,\n",
+       "        -2.1392, -2.2806, -1.9871, -2.3693, -2.1365, -2.2626, -2.5355, -2.3941,\n",
+       "        -2.3234, -2.4946, -2.6250, -2.5848, -2.2591, -2.4657, -2.4017, -2.4425,\n",
+       "        -2.7320, -2.6632, -2.2307, -2.2290, -2.0762, -3.2016, -2.6090, -2.1238,\n",
+       "        -2.3364, -2.4631, -2.7328, -2.4546, -2.4228, -2.0226, -2.1185, -2.3535,\n",
+       "        -2.1883, -2.6048, -2.2926, -1.9646, -2.0351, -2.6276, -2.7922, -2.8000,\n",
+       "        -2.5625, -2.4581, -2.3153, -3.0572, -2.7672, -2.3372, -2.5456, -2.7268,\n",
+       "        -2.6965, -2.5188, -2.5472, -2.1859, -2.6078, -2.4918, -2.2286, -2.2308,\n",
+       "        -1.9521, -2.2361, -1.8353, -1.5291, -2.3496, -1.7362, -2.2311, -2.0978,\n",
+       "        -3.5365, -2.5833, -2.4370, -2.2342, -2.3924, -2.2362, -1.7389, -2.1980,\n",
+       "        -2.6862, -2.3407, -2.6171, -2.6683, -2.0337, -2.6021, -2.1121])"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x_blens_unres.tensor[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "57d05cee",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([0.1322, 0.0849, 0.0894, 0.1675, 0.0961, 0.1064, 0.0700, 0.0551, 0.0906,\n",
+       "        0.0762, 0.1043, 0.0451, 0.0767, 0.0965, 0.1087, 0.0844, 0.0944, 0.0912,\n",
+       "        0.0694, 0.0881, 0.0733, 0.0541, 0.0762, 0.0920, 0.0801, 0.1059, 0.1078,\n",
+       "        0.0830, 0.1110, 0.0793, 0.0593, 0.0754, 0.0905, 0.0440, 0.0844, 0.0838,\n",
+       "        0.0980, 0.1534, 0.1018, 0.1152, 0.0807, 0.1384, 0.1113, 0.0681, 0.1031,\n",
+       "        0.1613, 0.0975, 0.1244, 0.0726, 0.0813, 0.0685, 0.0884, 0.1345, 0.0859,\n",
+       "        0.0869, 0.0919, 0.1177, 0.1022, 0.1371, 0.0935, 0.1181, 0.1041, 0.0792,\n",
+       "        0.0913, 0.0979, 0.0825, 0.0724, 0.0754, 0.1044, 0.0849, 0.0906, 0.0869,\n",
+       "        0.0651, 0.0697, 0.1075, 0.1076, 0.1254, 0.0407, 0.0736, 0.1196, 0.0967,\n",
+       "        0.0852, 0.0650, 0.0859, 0.0887, 0.1323, 0.1202, 0.0950, 0.1121, 0.0739,\n",
+       "        0.1010, 0.1402, 0.1307, 0.0723, 0.0613, 0.0608, 0.0771, 0.0856, 0.0987,\n",
+       "        0.0470, 0.0628, 0.0966, 0.0784, 0.0654, 0.0674, 0.0806, 0.0783, 0.1124,\n",
+       "        0.0737, 0.0828, 0.1077, 0.1074, 0.1420, 0.1069, 0.1596, 0.2167, 0.0954,\n",
+       "        0.1762, 0.1074, 0.1227, 0.0291, 0.0755, 0.0874, 0.1071, 0.0914, 0.1069,\n",
+       "        0.1757, 0.1110, 0.0681, 0.0963, 0.0730, 0.0694, 0.1308, 0.0741, 0.1210])"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "branch_lengths.tensor[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3689be42",
+   "metadata": {},
+   "source": [
+    "#### Invariant probability *q*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "edec3fb7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-2.1972246170043945\n",
+      "-1.89712\n",
+      "\n",
+      "var.Normal.sitemodel.pinv.unres\n",
+      "sitemodel.pinv.unres\n"
+     ]
+    }
+   ],
+   "source": [
+    "p_loc = torch.distributions.SigmoidTransform().inv(torch.tensor(pinv_init)).tolist()\n",
+    "p_scale_log = -1.89712\n",
+    "\n",
+    "pinv_unres_loc =  Parameter(pinv_unres_id+\".loc\", torch.tensor([p_loc]))\n",
+    "\n",
+    "pinv_unres_scale = TransformedParameter(\n",
+    "    pinv_unres_id+\".scale\",\n",
+    "    Parameter(pinv_unres_id+\".scale.unres\", \n",
+    "              torch.tensor([p_scale_log])),\n",
+    "    ExpTransform()\n",
+    ")\n",
+    "\n",
+    "\n",
+    "var_parameters.append(pinv_unres_loc)\n",
+    "var_parameters.append(pinv_unres_scale)\n",
+    "\n",
+    "\n",
+    "pinv_q = Distribution(\n",
+    "    var_id + \".\" + pinv_unres_id,\n",
+    "    torch.distributions.Normal,\n",
+    "    x_pinv_unres,\n",
+    "    OrderedDict({'loc': pinv_unres_loc, 'scale': pinv_unres_scale})\n",
+    ")\n",
+    "\n",
+    "\n",
+    "print(p_loc)\n",
+    "print(p_scale_log)\n",
+    "print()\n",
+    "print(pinv_q.id)\n",
+    "print(pinv_q.x.id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "612bf7e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with torch.no_grad():\n",
+    "    pinv_q.rsample([100])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "85ae2f21",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([-2.2672])"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x_pinv_unres.tensor[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "7a1bdb35",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([0.0939])"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pinv_param.tensor[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce8fab85",
+   "metadata": {},
+   "source": [
+    "#### GTR rates *q*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "7c76caab",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "var.Normal.substmodel.rates.unres\n",
+      "substmodel.rates.unres\n"
+     ]
+    }
+   ],
+   "source": [
+    "r_loc, r_scale_log = 0.5, -1.89712\n",
+    "\n",
+    "\n",
+    "rates_unres_loc = Parameter(rates_unres_id+\".loc\", torch.full((5,), r_loc))\n",
+    "\n",
+    "rates_unres_scale = TransformedParameter(\n",
+    "    rates_unres_id+\".scale\",\n",
+    "    Parameter(rates_unres_id+\".scale.unres\", \n",
+    "              torch.full((5,), r_scale_log)),\n",
+    "    ExpTransform()\n",
+    ")\n",
+    "\n",
+    "var_parameters.append(rates_unres_loc)\n",
+    "var_parameters.append(rates_unres_scale)\n",
+    "\n",
+    "rates_q = Distribution(\n",
+    "    var_id + \".\" + rates_unres_id,\n",
+    "    torch.distributions.Normal,\n",
+    "    x_rates_unres,\n",
+    "    OrderedDict({'loc': rates_unres_loc, 'scale': rates_unres_scale})\n",
+    ")\n",
+    "\n",
+    "print(rates_q.id)\n",
+    "print(rates_q.x.id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "d93a84c6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([100, 5])"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with torch.no_grad():\n",
+    "    rates_q.rsample([100])\n",
+    "    \n",
+    "rates_q.x.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42e14098",
+   "metadata": {},
+   "source": [
+    "#### GTR Frequencies *q*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "7820ee48",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "var.Normal.substmodel.rates.unres\n",
+      "substmodel.rates.unres\n"
+     ]
+    }
+   ],
+   "source": [
+    "f_loc, f_scale_log = 0.5, -1.89712\n",
+    "\n",
+    "\n",
+    "freqs_unres_loc = Parameter(freqs_unres_id+\".loc\", torch.full((3,), f_loc))\n",
+    "\n",
+    "freqs_unres_scale = TransformedParameter(\n",
+    "    freqs_unres_id+\".scale\",\n",
+    "    Parameter(freqs_unres_id+\".scale.unres\", \n",
+    "              torch.full((3,), f_scale_log)),\n",
+    "    ExpTransform()\n",
+    ")\n",
+    "\n",
+    "var_parameters.append(freqs_unres_loc)\n",
+    "var_parameters.append(freqs_unres_scale)\n",
+    "\n",
+    "freqs_q = Distribution(\n",
+    "    var_id + \".\" + freqs_unres_id,\n",
+    "    torch.distributions.Normal,\n",
+    "    x_freqs_unres,\n",
+    "    OrderedDict({'loc': freqs_unres_loc, 'scale': freqs_unres_scale})\n",
+    ")\n",
+    "\n",
+    "print(rates_q.id)\n",
+    "print(rates_q.x.id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "5f1890a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([100, 3])"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with torch.no_grad():\n",
+    "    freqs_q.rsample([100])\n",
+    "\n",
+    "freqs_q.x.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce758a7f",
+   "metadata": {},
+   "source": [
+    "### 2. Variational joint distribution *Q*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "69ff5724",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Joint variational\n",
+    "\n",
+    "var_joint_list = [blens_q, pinv_q, rates_q, freqs_q]\n",
+    "\n",
+    "var_joint_dist = JointDistributionModel('variational', var_joint_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "e2ce3162",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# rates_q.parameters()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "351ecf28",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "var.Normal.tree.blens.unres\n",
+      "var.Normal.sitemodel.pinv.unres\n",
+      "var.Normal.substmodel.rates.unres\n",
+      "var.Normal.substmodel.frequencies.unres\n"
+     ]
+    }
+   ],
+   "source": [
+    "for model in var_joint_dist._distributions.models():\n",
+    "    # _distributions attribute is a core.container.Container\n",
+    "    print(model.id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "5958bb13",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8\n"
+     ]
+    }
+   ],
+   "source": [
+    "## Get tensors of variational parameters\n",
+    "var_param_tensors = [p.tensor for p in var_parameters]\n",
+    "\n",
+    "print(len(var_param_tensors))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d50d231",
+   "metadata": {},
+   "source": [
+    "### 3. ELBO"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "7e775d40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elbo_samples = 1\n",
+    "\n",
+    "elbo = ELBO(\n",
+    "        id_='elbo',\n",
+    "        q=var_joint_dist,\n",
+    "        p=joint_dist,\n",
+    "        samples=torch.Size([elbo_samples]),\n",
+    "        entropy=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "e645b428",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# elbo()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd1b19e9",
+   "metadata": {},
+   "source": [
+    "## V. Fitting the variational model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "id": "608bd8ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "maximize=True\n",
+    "lr = 0.05 \n",
+    "# Fitting crashes when lr=0.1 and even sometimes with smaller values (invalid values in sampling)\n",
+    "weight_decay=0.001\n",
+    "\n",
+    "optimizer = torch.optim.Adam(var_param_tensors,\n",
+    "                             maximize=maximize,\n",
+    "                             lr=lr,\n",
+    "                             weight_decay=weight_decay)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "88353f35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lambda1r = lambda epoch: 1.0 / (epoch + 1)**0.5\n",
+    "\n",
+    "scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=lambda1r)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "18a9f4f8",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100\tELBO: -5663.874\tLogL: -5946.705\tLogQ: -25.098\n",
+      "tree length: 6.021\n",
+      "pinv: 0.207\n",
+      "GTR rates: ['0.306', '0.294', '0.090', '0.093', '0.168', '0.048']\n",
+      "GTR freqs: ['0.355', '0.253', '0.222', '0.171'] \n",
+      "\n",
+      "200\tELBO: -5184.143\tLogL: -5476.102\tLogQ: -19.176\n",
+      "tree length: 4.517\n",
+      "pinv: 0.265\n",
+      "GTR rates: ['0.265', '0.340', '0.075', '0.078', '0.199', '0.043']\n",
+      "GTR freqs: ['0.340', '0.234', '0.236', '0.190'] \n",
+      "\n",
+      "300\tELBO: -4902.405\tLogL: -5207.971\tLogQ: -25.322\n",
+      "tree length: 3.695\n",
+      "pinv: 0.305\n",
+      "GTR rates: ['0.226', '0.373', '0.068', '0.066', '0.221', '0.045']\n",
+      "GTR freqs: ['0.340', '0.222', '0.244', '0.195'] \n",
+      "\n",
+      "400\tELBO: -4718.143\tLogL: -5023.073\tLogQ: -19.024\n",
+      "tree length: 3.155\n",
+      "pinv: 0.338\n",
+      "GTR rates: ['0.191', '0.398', '0.066', '0.057', '0.245', '0.043']\n",
+      "GTR freqs: ['0.343', '0.211', '0.250', '0.197'] \n",
+      "\n",
+      "500\tELBO: -4631.680\tLogL: -4952.049\tLogQ: -31.433\n",
+      "tree length: 2.773\n",
+      "pinv: 0.365\n",
+      "GTR rates: ['0.175', '0.414', '0.062', '0.055', '0.250', '0.044']\n",
+      "GTR freqs: ['0.341', '0.210', '0.248', '0.201'] \n",
+      "\n",
+      "600\tELBO: -4497.688\tLogL: -4822.537\tLogQ: -32.973\n",
+      "tree length: 2.452\n",
+      "pinv: 0.388\n",
+      "GTR rates: ['0.159', '0.412', '0.064', '0.052', '0.268', '0.045']\n",
+      "GTR freqs: ['0.336', '0.210', '0.245', '0.209'] \n",
+      "\n",
+      "700\tELBO: -4399.073\tLogL: -4724.461\tLogQ: -30.092\n",
+      "tree length: 2.210\n",
+      "pinv: 0.404\n",
+      "GTR rates: ['0.150', '0.400', '0.066', '0.048', '0.291', '0.046']\n",
+      "GTR freqs: ['0.335', '0.212', '0.241', '0.211'] \n",
+      "\n",
+      "800\tELBO: -4341.078\tLogL: -4676.639\tLogQ: -38.539\n",
+      "tree length: 2.035\n",
+      "pinv: 0.417\n",
+      "GTR rates: ['0.143', '0.390', '0.067', '0.046', '0.306', '0.048']\n",
+      "GTR freqs: ['0.331', '0.215', '0.236', '0.218'] \n",
+      "\n",
+      "900\tELBO: -4273.585\tLogL: -4599.611\tLogQ: -27.544\n",
+      "tree length: 1.878\n",
+      "pinv: 0.438\n",
+      "GTR rates: ['0.137', '0.375', '0.067', '0.046', '0.324', '0.050']\n",
+      "GTR freqs: ['0.330', '0.220', '0.230', '0.220'] \n",
+      "\n",
+      "1000\tELBO: -4222.634\tLogL: -4573.235\tLogQ: -50.348\n",
+      "tree length: 1.743\n",
+      "pinv: 0.446\n",
+      "GTR rates: ['0.135', '0.360', '0.068', '0.044', '0.342', '0.051']\n",
+      "GTR freqs: ['0.329', '0.222', '0.225', '0.224'] \n",
+      "\n",
+      "1100\tELBO: -4203.244\tLogL: -4549.256\tLogQ: -45.692\n",
+      "tree length: 1.620\n",
+      "pinv: 0.461\n",
+      "GTR rates: ['0.132', '0.344', '0.072', '0.042', '0.358', '0.052']\n",
+      "GTR freqs: ['0.325', '0.225', '0.222', '0.228'] \n",
+      "\n",
+      "1200\tELBO: -4162.334\tLogL: -4511.456\tLogQ: -47.452\n",
+      "tree length: 1.529\n",
+      "pinv: 0.469\n",
+      "GTR rates: ['0.127', '0.338', '0.071', '0.039', '0.370', '0.056']\n",
+      "GTR freqs: ['0.324', '0.226', '0.220', '0.231'] \n",
+      "\n",
+      "1300\tELBO: -4110.642\tLogL: -4472.385\tLogQ: -58.292\n",
+      "tree length: 1.440\n",
+      "pinv: 0.476\n",
+      "GTR rates: ['0.128', '0.332', '0.071', '0.037', '0.378', '0.053']\n",
+      "GTR freqs: ['0.326', '0.227', '0.218', '0.229'] \n",
+      "\n",
+      "1400\tELBO: -4082.316\tLogL: -4446.176\tLogQ: -59.789\n",
+      "tree length: 1.358\n",
+      "pinv: 0.484\n",
+      "GTR rates: ['0.122', '0.330', '0.069', '0.037', '0.388', '0.055']\n",
+      "GTR freqs: ['0.328', '0.229', '0.216', '0.227'] \n",
+      "\n",
+      "1500\tELBO: -4054.306\tLogL: -4427.087\tLogQ: -68.250\n",
+      "tree length: 1.294\n",
+      "pinv: 0.491\n",
+      "GTR rates: ['0.122', '0.321', '0.069', '0.037', '0.396', '0.055']\n",
+      "GTR freqs: ['0.330', '0.225', '0.215', '0.231'] \n",
+      "\n",
+      "1600\tELBO: -4025.243\tLogL: -4385.263\tLogQ: -54.926\n",
+      "tree length: 1.218\n",
+      "pinv: 0.495\n",
+      "GTR rates: ['0.121', '0.326', '0.068', '0.033', '0.395', '0.056']\n",
+      "GTR freqs: ['0.327', '0.228', '0.214', '0.230'] \n",
+      "\n",
+      "1700\tELBO: -4033.330\tLogL: -4402.228\tLogQ: -63.885\n",
+      "tree length: 1.165\n",
+      "pinv: 0.502\n",
+      "GTR rates: ['0.120', '0.324', '0.069', '0.032', '0.400', '0.057']\n",
+      "GTR freqs: ['0.328', '0.226', '0.216', '0.230'] \n",
+      "\n",
+      "1800\tELBO: -3993.246\tLogL: -4361.485\tLogQ: -62.498\n",
+      "tree length: 1.121\n",
+      "pinv: 0.505\n",
+      "GTR rates: ['0.122', '0.325', '0.068', '0.029', '0.399', '0.056']\n",
+      "GTR freqs: ['0.329', '0.225', '0.215', '0.231'] \n",
+      "\n",
+      "1900\tELBO: -3985.402\tLogL: -4357.284\tLogQ: -65.584\n",
+      "tree length: 1.072\n",
+      "pinv: 0.512\n",
+      "GTR rates: ['0.116', '0.337', '0.069', '0.029', '0.392', '0.057']\n",
+      "GTR freqs: ['0.330', '0.227', '0.215', '0.228'] \n",
+      "\n",
+      "2000\tELBO: -3973.391\tLogL: -4356.711\tLogQ: -77.291\n",
+      "tree length: 1.034\n",
+      "pinv: 0.518\n",
+      "GTR rates: ['0.119', '0.331', '0.065', '0.028', '0.399', '0.058']\n",
+      "GTR freqs: ['0.332', '0.223', '0.216', '0.229'] \n",
+      "\n",
+      "2100\tELBO: -3932.597\tLogL: -4314.471\tLogQ: -74.258\n",
+      "tree length: 0.998\n",
+      "pinv: 0.517\n",
+      "GTR rates: ['0.121', '0.330', '0.068', '0.025', '0.398', '0.059']\n",
+      "GTR freqs: ['0.330', '0.225', '0.215', '0.230'] \n",
+      "\n",
+      "2200\tELBO: -3951.714\tLogL: -4329.644\tLogQ: -70.984\n",
+      "tree length: 0.958\n",
+      "pinv: 0.519\n",
+      "GTR rates: ['0.121', '0.321', '0.069', '0.025', '0.406', '0.058']\n",
+      "GTR freqs: ['0.330', '0.226', '0.216', '0.229'] \n",
+      "\n",
+      "2300\tELBO: -3902.026\tLogL: -4292.941\tLogQ: -83.339\n",
+      "tree length: 0.926\n",
+      "pinv: 0.524\n",
+      "GTR rates: ['0.121', '0.333', '0.065', '0.024', '0.400', '0.057']\n",
+      "GTR freqs: ['0.333', '0.226', '0.213', '0.228'] \n",
+      "\n",
+      "2400\tELBO: -3913.485\tLogL: -4303.768\tLogQ: -82.229\n",
+      "tree length: 0.890\n",
+      "pinv: 0.526\n",
+      "GTR rates: ['0.120', '0.329', '0.070', '0.024', '0.399', '0.059']\n",
+      "GTR freqs: ['0.332', '0.223', '0.218', '0.227'] \n",
+      "\n",
+      "2500\tELBO: -3883.908\tLogL: -4262.734\tLogQ: -70.043\n",
+      "tree length: 0.866\n",
+      "pinv: 0.529\n",
+      "GTR rates: ['0.116', '0.329', '0.068', '0.023', '0.404', '0.059']\n",
+      "GTR freqs: ['0.331', '0.224', '0.216', '0.229'] \n",
+      "\n",
+      "2600\tELBO: -3870.358\tLogL: -4258.323\tLogQ: -79.528\n",
+      "tree length: 0.842\n",
+      "pinv: 0.533\n",
+      "GTR rates: ['0.122', '0.334', '0.065', '0.021', '0.400', '0.059']\n",
+      "GTR freqs: ['0.332', '0.226', '0.213', '0.229'] \n",
+      "\n",
+      "2700\tELBO: -3867.218\tLogL: -4261.362\tLogQ: -85.359\n",
+      "tree length: 0.814\n",
+      "pinv: 0.530\n",
+      "GTR rates: ['0.120', '0.336', '0.064', '0.020', '0.399', '0.060']\n",
+      "GTR freqs: ['0.333', '0.228', '0.214', '0.226'] \n",
+      "\n",
+      "2800\tELBO: -3856.502\tLogL: -4244.646\tLogQ: -78.921\n",
+      "tree length: 0.802\n",
+      "pinv: 0.532\n",
+      "GTR rates: ['0.119', '0.342', '0.065', '0.020', '0.394', '0.059']\n",
+      "GTR freqs: ['0.334', '0.224', '0.215', '0.226'] \n",
+      "\n",
+      "2900\tELBO: -3841.226\tLogL: -4230.678\tLogQ: -79.660\n",
+      "tree length: 0.772\n",
+      "pinv: 0.538\n",
+      "GTR rates: ['0.120', '0.340', '0.068', '0.020', '0.394', '0.059']\n",
+      "GTR freqs: ['0.332', '0.223', '0.217', '0.228'] \n",
+      "\n",
+      "3000\tELBO: -3861.921\tLogL: -4256.590\tLogQ: -85.453\n",
+      "tree length: 0.760\n",
+      "pinv: 0.541\n",
+      "GTR rates: ['0.119', '0.336', '0.065', '0.019', '0.399', '0.061']\n",
+      "GTR freqs: ['0.332', '0.225', '0.216', '0.227'] \n",
+      "\n",
+      "3100\tELBO: -3841.372\tLogL: -4247.299\tLogQ: -96.620\n",
+      "tree length: 0.746\n",
+      "pinv: 0.542\n",
+      "GTR rates: ['0.121', '0.335', '0.068', '0.019', '0.396', '0.061']\n",
+      "GTR freqs: ['0.334', '0.223', '0.215', '0.228'] \n",
+      "\n",
+      "3200\tELBO: -3822.053\tLogL: -4231.880\tLogQ: -99.894\n",
+      "tree length: 0.725\n",
+      "pinv: 0.543\n",
+      "GTR rates: ['0.120', '0.338', '0.066', '0.020', '0.396', '0.061']\n",
+      "GTR freqs: ['0.333', '0.221', '0.216', '0.229'] \n",
+      "\n",
+      "3300\tELBO: -3822.472\tLogL: -4230.432\tLogQ: -97.843\n",
+      "tree length: 0.711\n",
+      "pinv: 0.542\n",
+      "GTR rates: ['0.121', '0.340', '0.064', '0.018', '0.397', '0.060']\n",
+      "GTR freqs: ['0.336', '0.220', '0.214', '0.230'] \n",
+      "\n",
+      "3400\tELBO: -3822.091\tLogL: -4213.827\tLogQ: -81.382\n",
+      "tree length: 0.693\n",
+      "pinv: 0.548\n",
+      "GTR rates: ['0.119', '0.337', '0.067', '0.019', '0.394', '0.065']\n",
+      "GTR freqs: ['0.336', '0.223', '0.215', '0.226'] \n",
+      "\n",
+      "3500\tELBO: -3823.239\tLogL: -4217.022\tLogQ: -83.575\n",
+      "tree length: 0.684\n",
+      "pinv: 0.553\n",
+      "GTR rates: ['0.119', '0.340', '0.068', '0.019', '0.392', '0.063']\n",
+      "GTR freqs: ['0.337', '0.221', '0.214', '0.227'] \n",
+      "\n",
+      "3600\tELBO: -3825.106\tLogL: -4240.146\tLogQ: -104.897\n",
+      "tree length: 0.666\n",
+      "pinv: 0.550\n",
+      "GTR rates: ['0.118', '0.344', '0.062', '0.019', '0.396', '0.060']\n",
+      "GTR freqs: ['0.335', '0.221', '0.218', '0.226'] \n",
+      "\n",
+      "3700\tELBO: -3828.955\tLogL: -4241.841\tLogQ: -102.890\n",
+      "tree length: 0.659\n",
+      "pinv: 0.553\n",
+      "GTR rates: ['0.122', '0.340', '0.065', '0.019', '0.392', '0.063']\n",
+      "GTR freqs: ['0.337', '0.224', '0.213', '0.226'] \n",
+      "\n",
+      "3800\tELBO: -3827.362\tLogL: -4248.195\tLogQ: -110.747\n",
+      "tree length: 0.643\n",
+      "pinv: 0.555\n",
+      "GTR rates: ['0.122', '0.340', '0.065', '0.018', '0.391', '0.063']\n",
+      "GTR freqs: ['0.337', '0.220', '0.214', '0.228'] \n",
+      "\n",
+      "3900\tELBO: -3797.685\tLogL: -4208.508\tLogQ: -100.186\n",
+      "tree length: 0.636\n",
+      "pinv: 0.555\n",
+      "GTR rates: ['0.120', '0.341', '0.065', '0.016', '0.397', '0.061']\n",
+      "GTR freqs: ['0.332', '0.224', '0.215', '0.229'] \n",
+      "\n",
+      "4000\tELBO: -3798.247\tLogL: -4218.093\tLogQ: -109.159\n",
+      "tree length: 0.619\n",
+      "pinv: 0.554\n",
+      "GTR rates: ['0.122', '0.338', '0.066', '0.017', '0.395', '0.062']\n",
+      "GTR freqs: ['0.335', '0.221', '0.215', '0.228'] \n",
+      "\n",
+      "4100\tELBO: -3795.452\tLogL: -4196.616\tLogQ: -90.225\n",
+      "tree length: 0.616\n",
+      "pinv: 0.562\n",
+      "GTR rates: ['0.125', '0.342', '0.065', '0.016', '0.391', '0.061']\n",
+      "GTR freqs: ['0.338', '0.219', '0.214', '0.229'] \n",
+      "\n",
+      "4200\tELBO: -3788.324\tLogL: -4204.718\tLogQ: -105.378\n",
+      "tree length: 0.605\n",
+      "pinv: 0.565\n",
+      "GTR rates: ['0.123', '0.345', '0.064', '0.016', '0.391', '0.061']\n",
+      "GTR freqs: ['0.334', '0.222', '0.216', '0.228'] \n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4300\tELBO: -3778.479\tLogL: -4197.314\tLogQ: -107.888\n",
+      "tree length: 0.601\n",
+      "pinv: 0.560\n",
+      "GTR rates: ['0.119', '0.344', '0.067', '0.016', '0.392', '0.062']\n",
+      "GTR freqs: ['0.335', '0.222', '0.215', '0.228'] \n",
+      "\n",
+      "4400\tELBO: -3793.816\tLogL: -4210.344\tLogQ: -105.724\n",
+      "tree length: 0.593\n",
+      "pinv: 0.561\n",
+      "GTR rates: ['0.120', '0.341', '0.067', '0.015', '0.394', '0.062']\n",
+      "GTR freqs: ['0.334', '0.221', '0.219', '0.227'] \n",
+      "\n",
+      "4500\tELBO: -3788.309\tLogL: -4202.057\tLogQ: -102.100\n",
+      "tree length: 0.585\n",
+      "pinv: 0.560\n",
+      "GTR rates: ['0.122', '0.347', '0.066', '0.015', '0.388', '0.062']\n",
+      "GTR freqs: ['0.336', '0.221', '0.214', '0.229'] \n",
+      "\n",
+      "4600\tELBO: -3780.934\tLogL: -4190.281\tLogQ: -97.945\n",
+      "tree length: 0.578\n",
+      "pinv: 0.564\n",
+      "GTR rates: ['0.120', '0.348', '0.066', '0.016', '0.390', '0.060']\n",
+      "GTR freqs: ['0.336', '0.221', '0.214', '0.228'] \n",
+      "\n",
+      "4700\tELBO: -3769.205\tLogL: -4190.500\tLogQ: -110.423\n",
+      "tree length: 0.570\n",
+      "pinv: 0.566\n",
+      "GTR rates: ['0.121', '0.346', '0.066', '0.016', '0.389', '0.061']\n",
+      "GTR freqs: ['0.336', '0.222', '0.214', '0.228'] \n",
+      "\n",
+      "4800\tELBO: -3760.610\tLogL: -4167.029\tLogQ: -94.557\n",
+      "tree length: 0.566\n",
+      "pinv: 0.567\n",
+      "GTR rates: ['0.125', '0.342', '0.066', '0.016', '0.390', '0.061']\n",
+      "GTR freqs: ['0.338', '0.220', '0.215', '0.228'] \n",
+      "\n",
+      "4900\tELBO: -3770.199\tLogL: -4175.849\tLogQ: -94.387\n",
+      "tree length: 0.555\n",
+      "pinv: 0.568\n",
+      "GTR rates: ['0.123', '0.346', '0.063', '0.016', '0.391', '0.061']\n",
+      "GTR freqs: ['0.337', '0.220', '0.215', '0.228'] \n",
+      "\n",
+      "5000\tELBO: -3769.070\tLogL: -4185.594\tLogQ: -104.954\n",
+      "tree length: 0.549\n",
+      "pinv: 0.568\n",
+      "GTR rates: ['0.120', '0.345', '0.066', '0.015', '0.391', '0.063']\n",
+      "GTR freqs: ['0.336', '0.222', '0.214', '0.229'] \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "iterations = 5000\n",
+    "trials = 10\n",
+    "var_samples = 100\n",
+    "print_every = 100\n",
+    "\n",
+    "\n",
+    "for p in var_param_tensors:\n",
+    "    p.requires_grad = True\n",
+    "\n",
+    "\n",
+    "for epoch in range(1, iterations + 1):\n",
+    "\n",
+    "    for trial in range(trials):\n",
+    "        optimizer.zero_grad()\n",
+    "        loss = elbo()\n",
+    "\n",
+    "        optimizer.zero_grad()\n",
+    "        loss.backward()\n",
+    "\n",
+    "        for p in var_param_tensors:\n",
+    "            retry = torch.any(torch.isinf(p.grad)) or torch.any(\n",
+    "                torch.isnan(p.grad)\n",
+    "            )\n",
+    "            if retry:\n",
+    "                break\n",
+    "        if not retry:\n",
+    "            break\n",
+    "        else:\n",
+    "            for p in var_parameters:\n",
+    "                p.fire_parameter_changed()\n",
+    "\n",
+    "    optimizer.step()\n",
+    "\n",
+    "    scheduler.step()\n",
+    "\n",
+    "    for p in var_parameters:\n",
+    "        p.fire_parameter_changed()\n",
+    "\n",
+    "    with torch.no_grad():\n",
+    "        logl = tree_likelihood.lp.mean(0).item()\n",
+    "        logq = var_joint_dist.lp.mean(0).item()\n",
+    "\n",
+    "        # Sample from variational distributions q()\n",
+    "        for var_distr in var_joint_list:\n",
+    "            var_distr.sample([var_samples])\n",
+    "\n",
+    "        mean_tree_length = branch_lengths.tensor.sum(1).mean()\n",
+    "        mean_pinv = pinv_param.tensor.mean()\n",
+    "        mean_rates = rates_param.tensor.mean(0)\n",
+    "        mean_freqs = freqs_param.tensor.mean(0)\n",
+    "\n",
+    "        # printing\n",
+    "        if epoch % print_every == 0:\n",
+    "            print(f'{epoch}\\tELBO: {loss:.3f}\\tLogL: {logl:.3f}\\tLogQ: {logq:.3f}')\n",
+    "            print(f'tree length: {mean_tree_length:.3f}\\npinv: {mean_pinv:.3f}')\n",
+    "            print('GTR rates:', [f\"{r:.3f}\" for r in mean_rates.tolist()])\n",
+    "            print(f'GTR freqs:',[f\"{f:.3f}\" for f in mean_freqs.tolist()],'\\n') \n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "t111",
+   "language": "python",
+   "name": "t111"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/FluA_GTR_I_torchtree_cli.ipynb
+++ b/notebooks/FluA_GTR_I_torchtree_cli.ipynb
@@ -1,0 +1,1717 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bb589fea",
+   "metadata": {},
+   "source": [
+    "# Phylogenetic estimation using torchtree CLI\n",
+    "\n",
+    "> [Amine Remita](https://github.com/maremita), Department of Computer Science, Université du Québec à Montréal\n",
+    "\n",
+    "This notebook shows an example of using torchtree to generate json file to infer the branch lengths and GTR+I parameters with fixed topology."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cb79912f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment if not included in ipython config\n",
+    "# %load_ext autoreload\n",
+    "# %autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e2d93f60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torchtree import Parameter\n",
+    "from torchtree.evolution.alignment import read_fasta_sequences\n",
+    "from torchtree.evolution.tree_model import UnRootedTreeModel\n",
+    "from torchtree.distributions import Distribution\n",
+    "\n",
+    "from torchtree.cli.advi import create_meanfield\n",
+    "from torchtree.cli.jacobians import create_jacobians\n",
+    "\n",
+    "from pprint import pprint\n",
+    "from json import dump\n",
+    "\n",
+    "import torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "21667180",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The results of this notebook should comparable with those generated using torchtree-cli and torchtree\n",
+    "# \n",
+    "# torchtree-cli advi -m GTR -C 1 -I -i ../data/fluA.fasta -t ../data/fluA.tree > fluA_gtr_i.json\n",
+    "# torchtree fluA_gtr_i.json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "34814357",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# seed = 42\n",
+    "# torch.manual_seed(seed)\n",
+    "# np.random.seed(seed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9b6f642c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FluA dataset\n",
+    "\n",
+    "# Input files\n",
+    "newick_file = \"../data/fluA.tree\"\n",
+    "fasta_file = \"../data/fluA.fasta\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f0d2e0d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Output files\n",
+    "# TODO it's better to put these files in a separate folder (results/ for example)\n",
+    "\n",
+    "json_outfile= \"fluA_gtr_i.json\"\n",
+    "checkpoint_file = \"fluA_checkpoint.json\"\n",
+    "file_sample_name = 'fluA_samples.csv'\n",
+    "tree_file_name = 'fluA_samples.trees'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9baba0ec",
+   "metadata": {},
+   "source": [
+    "## I. Building alignment and taxa dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b0797ff4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(newick_file, 'r') as fp:\n",
+    "    newick = fp.read()\n",
+    "    newick = newick.strip()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "dd1b28ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Parse fasta file\n",
+    "\n",
+    "sequences = read_fasta_sequences(fasta_file)\n",
+    "sequence_list = []\n",
+    "taxa_list = []\n",
+    "\n",
+    "for sequence in sequences:\n",
+    "    sequence_list.append(\n",
+    "        {'taxon': sequence.taxon, 'sequence': sequence.sequence}\n",
+    "    )\n",
+    "    taxa_list.append({'id': sequence.taxon, 'type': 'Taxon'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d70d2210",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Create taxa dictionary\n",
+    "taxa = {'id': \"taxa\", \n",
+    "        'type': 'Taxa', \n",
+    "        'taxa': taxa_list}\n",
+    "\n",
+    "nb_blens = len(taxa['taxa']) * 2 - 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c7026419",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Create alignment dictionary\n",
+    "alignment = {\n",
+    "    'id': \"alignment\",\n",
+    "    'type': 'Alignment',\n",
+    "    'datatype':{\n",
+    "        \"id\": \"data_type\",\n",
+    "        \"type\": \"NucleotideDataType\"\n",
+    "    },\n",
+    "    'taxa': \"taxa\",\n",
+    "    \"sequences\":sequence_list\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b74641b0",
+   "metadata": {},
+   "source": [
+    "## II. Evolutionary parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "7cd12f09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tree_id = \"tree\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "defc17fd",
+   "metadata": {},
+   "source": [
+    "#### Initialize branch length parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "89cab55e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "branch_lengths = Parameter.json_factory(\n",
+    "    f'{tree_id}.blens', \n",
+    "    **{'tensor': 0.1, 'full': [nb_blens]}\n",
+    ")\n",
+    "\n",
+    "branch_lengths['lower'] = 0.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "026678e2",
+   "metadata": {},
+   "source": [
+    "#### Initialize site model parameter (pinv)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "7ce42498",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "site_model_id = \"sitemodel\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "5d3342d9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'sitemodel',\n",
+       " 'type': 'InvariantSiteModel',\n",
+       " 'invariant': {'id': 'sitemodel.pinv',\n",
+       "  'type': 'Parameter',\n",
+       "  'tensor': [0.1],\n",
+       "  'lower': 0,\n",
+       "  'upper': 1}}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prop = Parameter.json_factory(f'{site_model_id}.pinv', **{'tensor': [0.1]})\n",
+    "prop['lower'] = 0\n",
+    "prop['upper'] = 1\n",
+    "\n",
+    "site_model = {\n",
+    "    'id': site_model_id, \n",
+    "    'type': 'InvariantSiteModel', \n",
+    "    'invariant': prop}\n",
+    "\n",
+    "site_model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ebf81e3",
+   "metadata": {},
+   "source": [
+    "#### Initialize GTR substitution model parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "c753c2a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subst_model_id = \"substmodel\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "fda4b9a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Rates\n",
+    "rates = Parameter.json_factory(\n",
+    "    \"{}.rates\".format(subst_model_id), \n",
+    "    **{'tensor': 1 / 6, 'full': [6]}\n",
+    ")\n",
+    "rates['simplex'] = True\n",
+    "# rates['transform'] = 'torch.distributions.StickBreakingTransform'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "67ea902b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Relative frequencies\n",
+    "\n",
+    "frequencies = Parameter.json_factory(\n",
+    "    \"{}.frequencies\".format(subst_model_id),\n",
+    "    **{'tensor': [0.25] * 4}\n",
+    ")\n",
+    "\n",
+    "frequencies['simplex'] = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "150b7e56",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'substmodel',\n",
+       " 'type': 'GTR',\n",
+       " 'rates': {'id': 'substmodel.rates',\n",
+       "  'type': 'Parameter',\n",
+       "  'full': [6],\n",
+       "  'tensor': 0.16666666666666666,\n",
+       "  'simplex': True},\n",
+       " 'frequencies': {'id': 'substmodel.frequencies',\n",
+       "  'type': 'Parameter',\n",
+       "  'tensor': [0.25, 0.25, 0.25, 0.25],\n",
+       "  'simplex': True}}"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "## The GTR model\n",
+    "\n",
+    "subst_model = {\n",
+    "    'id': subst_model_id, \n",
+    "    'type': 'GTR',\n",
+    "    \"rates\": rates,\n",
+    "    \"frequencies\": frequencies\n",
+    "}\n",
+    "\n",
+    "subst_model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4ff7277",
+   "metadata": {},
+   "source": [
+    "## III. Evolutionary joint distribution (tree likelihood + priors)\n",
+    "\n",
+    "### 1. Tree Likelihood"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d286cdc5",
+   "metadata": {},
+   "source": [
+    "#### Initialize tree model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "8ad4c755",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "tree_model = UnRootedTreeModel.json_factory(\n",
+    "    tree_id, newick, branch_lengths, 'taxa')\n",
+    "\n",
+    "# pprint(tree_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26d7664c",
+   "metadata": {},
+   "source": [
+    "#### Initialize site pattern model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "87dc0df0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'patterns', 'type': 'SitePattern', 'alignment': 'alignment'}"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "site_pattern_id = \"patterns\"\n",
+    "\n",
+    "site_pattern = {\n",
+    "    'id': site_pattern_id, \n",
+    "    'type': 'SitePattern', \n",
+    "    'alignment': 'alignment'}\n",
+    "\n",
+    "site_pattern"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d15fa93",
+   "metadata": {},
+   "source": [
+    "#### Initialize tree likelihood model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "f65411cb",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "tree_likelihood = {\n",
+    "        'id': 'like',\n",
+    "        'type': 'TreeLikelihoodModel',\n",
+    "        'tree_model': tree_model,\n",
+    "        'site_model': site_model,\n",
+    "        'site_pattern': site_pattern,\n",
+    "        'substitution_model': subst_model,\n",
+    "    }\n",
+    "\n",
+    "# pprint(tree_likelihood)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "436f0c28",
+   "metadata": {},
+   "source": [
+    "### 2. Priors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26912336",
+   "metadata": {},
+   "source": [
+    "#### Branch lengths *p*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "fe0ea59a",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'tree.blens.prior',\n",
+       " 'type': 'Distribution',\n",
+       " 'distribution': 'torch.distributions.Exponential',\n",
+       " 'x': 'tree.blens',\n",
+       " 'parameters': {'rate': 10.0}}"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "blens_prior = Distribution.json_factory(\n",
+    "    f'{tree_id}.blens.prior',\n",
+    "    'torch.distributions.Exponential',\n",
+    "    f'{tree_id}.blens',\n",
+    "    {'rate': 10.0}\n",
+    ")\n",
+    "\n",
+    "blens_prior"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a665dc5",
+   "metadata": {},
+   "source": [
+    "#### Invariant probability *p*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "0a2e8765",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'sitemodel.pinv.prior',\n",
+       " 'type': 'Distribution',\n",
+       " 'distribution': 'torch.distributions.Exponential',\n",
+       " 'x': 'sitemodel.pinv',\n",
+       " 'parameters': {'rate': 2.0}}"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "## Remark: torchtree-cli does not add a prior on pinv when using -I\n",
+    "\n",
+    "site_model_prior = Distribution.json_factory(\n",
+    "    f'{site_model_id}.pinv.prior',\n",
+    "    'torch.distributions.Exponential',\n",
+    "    f'{site_model_id}.pinv',\n",
+    "    {'rate': 2.0}\n",
+    ")\n",
+    "\n",
+    "site_model_prior"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7161ca2",
+   "metadata": {},
+   "source": [
+    "#### GTR rates *p*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "91b9ab1b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'substmodel.rates.prior',\n",
+       " 'type': 'Distribution',\n",
+       " 'distribution': 'torch.distributions.Dirichlet',\n",
+       " 'x': 'substmodel.rates',\n",
+       " 'parameters': {'concentration': [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]}}"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rates_prior = Distribution.json_factory(\n",
+    "    f'{subst_model_id}.rates.prior',\n",
+    "    'torch.distributions.Dirichlet',\n",
+    "    f'{subst_model_id}.rates',\n",
+    "    {'concentration': [1.0] * 6}\n",
+    ")\n",
+    "\n",
+    "rates_prior"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef7980de",
+   "metadata": {},
+   "source": [
+    "#### GTR Frequencies *p*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "58da1928",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'substmodel.frequencies.prior',\n",
+       " 'type': 'Distribution',\n",
+       " 'distribution': 'torch.distributions.Dirichlet',\n",
+       " 'x': 'substmodel.frequencies',\n",
+       " 'parameters': {'concentration': [1.0, 1.0, 1.0, 1.0]}}"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "freqs_prior = Distribution.json_factory(\n",
+    "    f'{subst_model_id}.frequencies.prior',\n",
+    "    'torch.distributions.Dirichlet',\n",
+    "    f'{subst_model_id}.frequencies',\n",
+    "    {'concentration': [1.0] * 4}\n",
+    ")\n",
+    "\n",
+    "freqs_prior"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "4f777cd3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'id': 'tree.blens.prior',\n",
+       "  'type': 'Distribution',\n",
+       "  'distribution': 'torch.distributions.Exponential',\n",
+       "  'x': 'tree.blens',\n",
+       "  'parameters': {'rate': 10.0}},\n",
+       " {'id': 'sitemodel.pinv.prior',\n",
+       "  'type': 'Distribution',\n",
+       "  'distribution': 'torch.distributions.Exponential',\n",
+       "  'x': 'sitemodel.pinv',\n",
+       "  'parameters': {'rate': 2.0}},\n",
+       " {'id': 'substmodel.frequencies.prior',\n",
+       "  'type': 'Distribution',\n",
+       "  'distribution': 'torch.distributions.Dirichlet',\n",
+       "  'x': 'substmodel.frequencies',\n",
+       "  'parameters': {'concentration': [1.0, 1.0, 1.0, 1.0]}},\n",
+       " {'id': 'substmodel.rates.prior',\n",
+       "  'type': 'Distribution',\n",
+       "  'distribution': 'torch.distributions.Dirichlet',\n",
+       "  'x': 'substmodel.rates',\n",
+       "  'parameters': {'concentration': [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]}}]"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prior_joint_list = [blens_prior, site_model_prior, freqs_prior, rates_prior]\n",
+    "prior_joint_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13e93ed9",
+   "metadata": {},
+   "source": [
+    "### 3. Evolutionary joint distribution *P*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "865e01b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "joint_list = [tree_likelihood] + prior_joint_list\n",
+    "\n",
+    "joint_dic = {\n",
+    "    'id': 'joint',\n",
+    "    'type': 'JointDistributionModel',\n",
+    "    'distributions': joint_list\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "9e88d00c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'id': 'taxa',\n",
+       "  'type': 'Taxa',\n",
+       "  'taxa': [{'id': 'A_Belgium_2_1981', 'type': 'Taxon'},\n",
+       "   {'id': 'A_ChristHospital_231_1982', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Philippines_2_1982', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Baylor1B_1983', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Oita_3_1983', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Texas_12764_1983', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Alaska_8_1984', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Caen_1_1984', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Texas_17988_1984', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Colorado_2_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Guangdong_9_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Guizhou_1_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_LosAngeles_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Qingdao_10_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Shanghai_11_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Sichuan_2_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Sydney_1_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Tokyo_1275_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Victoria_7_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Alaska_9_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Beijing_32_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_California_271_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Finland_205_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Harbin_15_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Hawaii_3_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Indonesia_3946_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Perth_1_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Qingdao_53_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Sapporo_304_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_SouthAustralia_36_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Tianjin_33_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Umea_1_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Victoria_29_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Wellington_66_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Aichi_69_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Akita_1_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Argentina_3779_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_England_67_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_France_1109_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_HongKong_1_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Johannesburg_33_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Mexico_3255_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Pennsylvania_7_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Romania_160_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Santiago_7198_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Shangdong_5_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Singapore_7_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Thailand_75_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Vermont_3_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Athens_1_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Christchurch_45_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Cordoba_V185_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Greece_103_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_JOHANNESBURG_3_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_MALMO_1_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Nagasaki_76_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Neuquen_V541_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_PERTH_24_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Pusan_68_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Seoul_37_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Switzerland_7729_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Tucuman_V425_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Ushuaia_R127_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Waikato_12_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Czechoslovakia_4_1986', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Leningrad_360_1986', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Memphis_6_1986', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Wellington_4_1985', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Tonga_23_1985', 'type': 'Taxon'}]},\n",
+       " {'id': 'alignment',\n",
+       "  'type': 'Alignment',\n",
+       "  'datatype': {'id': 'data_type', 'type': 'NucleotideDataType'},\n",
+       "  'taxa': 'taxa',\n",
+       "  'sequences': [{'taxon': 'A_Belgium_2_1981',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCATCGGATCCTTGATGGGAAAAACTGCACACTGGTAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTTCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCGTCAGGCACCCTGGAGTTTATCAATGAAAGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGATAAAAGTTTCTTCAGTAGACTGAATTGGTTGTACGAATCAGAAAGCAGATATCCAGTGCTGAACGTGACTATGCCAAACAATGGCAATTTTGACAAACTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTATAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTAATTAATAGTAATGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATGCGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAGCCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAAGTATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_ChristHospital_231_1982',\n",
+       "    'sequence': 'CAAAACCTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAAAATATGCGGCAGTCCTCACCGAATCCTTGATGGGAAAAACTGCACACTGGTAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTCTCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCGTCAGGCACCCTGGAGTTTATCAATGAAAGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGATAACAGTTTCTTCAGTAGACTGAATTGGTTGTATGAATCAGAAAGCAAATATCCAGTGCTGAACGTGACTATGCCAAACAATGGCAATTTTGACAAACTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAAACTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAACCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGCTAATTAATAGTAATGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAGCCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAAGTATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAAAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Philippines_2_1982',\n",
+       "    'sequence': 'CAAAACCTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGGATATGCGACAGTCCTCACCGAATCCTTGATGGGAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATACTTGCAAAAGGGGATCTAATAACAGTTTCTTCAGTAGACTGAACTGGTTGTACGAATCAGAAAGCAAATATCCAGTGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGATTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATATTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGTATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTAATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAGCCCTTTCAAAACGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Baylor1B_1983',\n",
+       "    'sequence': 'CAAAACCTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGGAAAAACTGCACACTGGTAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTTCAAAATGAGAAATGGGACCTTTTTATTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCGTCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGATAACAGTTTCTTCAGTAGACTGAATTGGTTGTACGAATCAGAAAGCAAATATCCAGTGCTGAACGTGACTATGCCAAACAATGGCAATTTTGACAAACTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAACCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGCTAATTAATAGTAATGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAGCCCTTTCAAAATGTAAACAAGATCACATATGGGACATGTCCTAAATACGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Oita_3_1983',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGGAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACAAATCAGAAAGCAAATATCCAGTGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGCAGAATAAGTATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTAATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Texas_12764_1983',\n",
+       "    'sequence': 'CAAAACCTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACGAATCAGAAAGCAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATTACATATGGGGCATGTCCCAGGTATGTTAAACAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Alaska_8_1984',\n",
+       "    'sequence': '---AAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTACCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACGAGTCAGAAAGCAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGATCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGCCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGTATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTAATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCTGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Caen_1_1984',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGGAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAACGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACAAATCAGAAAGCAAATATCCAGTGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGTATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTAATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTATGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Texas_17988_1984',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGCTCTTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGGAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGTCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAATTTACCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACGAATCAGAAAGCAAATATCCAGTGCTGAACGTGAGTATGCCAAACAATGGCAAATTAGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGTACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGTATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTAATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCGAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Colorado_2_1987',\n",
+       "    'sequence': 'CAAAAACTTCCTGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACTCTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGTATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAAACTATATGTTCGAGCATCAGGAAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Guangdong_9_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGGTCACGGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Guizhou_1_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTCCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGGGTGGGGGAAGCTATTCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGAATCAGAATGCAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAGCTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_LosAngeles_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGATCACGGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Qingdao_10_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATTCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGCCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Shanghai_11_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGAACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Sichuan_2_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGGTCACGGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Sydney_1_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAGGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATTCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAAACTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Tokyo_1275_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTATAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAGGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATACTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATCTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACTGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGAGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Victoria_7_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATTCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Alaska_9_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCAAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATTCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Beijing_32_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCTTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_California_271_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGAAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTTTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Finland_205_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAGAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGTGACAGTCCTCACCGAATCCTTGATGGAAAAAATTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTACCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGAGTGGGGAAAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACRAATCAGATTACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCCACCAAAAGAAGCCAACAAACTGTGATCCCGAATATCGGGTCCAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTGAAACCGGGAGACATACTTTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGAACTGGGAAAAGCTCGATAATGAGATCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAACGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACT---'},\n",
+       "   {'taxon': 'A_Harbin_15_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTACAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGATCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Hawaii_3_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCCCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCGCTAAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Indonesia_3946_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGGCATCATGCAGTGCCAAACGGAACTCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTCGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGACTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAATTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGAGTGGGGACAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCATCGCTGAACGTGACTATGCCAAACAATGACAAATTTGACAAGTTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAGCCTATATATTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTCCAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACCGGGAATCTAATTGCTCCACGGGGTTACTTCAAAATACGAACTGGGAAAAGCTCGATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATCCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Perth_1_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTATGCCTGGGACATCATGCAGTGCCAAATGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATAGCTTCCAAAACAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAAGTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCATCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Qingdao_53_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGAAGTCGCTCAGGATGGGGGAAGCTGTGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCCGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Sapporo_304_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGTTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_SouthAustralia_36_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGTGACAGTCCTCACCGAATCCTTGATGGAAAAAATTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTACCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGAGTGGGGAAAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACGAATCAGATTACAAATACCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCCACCAAAAGAAGCCAACAAACTGTGATCCCGAATATCGGGTCCAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGAACTGGGAAAAGCTCGATAATGAGATCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATCCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGAATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Tianjin_33_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCAGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCTCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Umea_1_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGGCATCATGCAGTGCCAAACGGAACTCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAAAATATGCGACAGTCCTCACCGAATCCTCGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGACTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAATTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGAGTGGGGACAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGACAAATTTGACAAGTTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAGCCTATATATTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGTCAACAAACTGTAATCCCAAATATCGGGTCCAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACCGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAACTGGGAAAAGCTCGATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATCCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Victoria_29_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTATGCCTGGGGCATCATGCAGTGCCAAACGGAACTCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTCGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAATTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGAATGGGGGCAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAACGACAAATTTGACAAGTTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAGCCTATATATTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTCCAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACCGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGGACTGGGAAAAGCTCGATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATCCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGAATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Wellington_66_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGGCATCATGCAGTGCCAAACGGAACTCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTCCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTCGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAATTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCCCTCAGAATGGGGACAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAACGCTGAACGTGACTATGCCAAACAATGACAAATTTGACAAGTTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAGCCTATATATTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTCCAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACCGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGGACTGGGAAAAGCTCGATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATCCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Aichi_69_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGACTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTACCAATGAAGGCTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTATCTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGGTTAACAGCACAGGGAATCTAATTGCTCCTCGAGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGATCAGATGCACCCATTGACAACTGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACT---'},\n",
+       "   {'taxon': 'A_Akita_1_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAGAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGCTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTTTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATTTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACT---'},\n",
+       "   {'taxon': 'A_Argentina_3779_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCCCAACAGGTAGAATATGCGACAGCCCTCACCGAATCCTTGATGGAAAGAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAACGAAAACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCACACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGTCCAAACCAGCCTATATGTCCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGGATATCGGGTATAGACCATGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCCAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGGAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_England_67_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCCCAACAGGTAGAATATGCAACAGTCCTCACCGAATCCTTGATGGAAAGAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGACTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAACGAAAACTTCAATTGGACCGGAGTCGCTCAGGATGGGAAAAGCTATACTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTCCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGGATATCGGGTATAGACCATGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTTAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCATCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_France_1109_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACAGAATCCTTGATGGGAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTAATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTACCAATGAGGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACTAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGAAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATACGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_HongKong_1_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCCCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAGAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAACGAAAACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTCCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGGATATCGGGTATAGACCATGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTCTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATTATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Johannesburg_33_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCCCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAGAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAACGAAAACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTCCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGGATATCGGGTATAGACCATGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Mexico_3255_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGTGACAGTCCTCACCGAATCCTTGATGGAAAAAATTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGATCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGAGTGGGGAAAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACGAATCAGATTACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCCACCAAAAGAAGCCAACAAACTGTGATCCCGAATATCGGGTCCAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTGAAACCGGGAGACATACTTTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGAACTGGGAAAAGCTCGATAATGAGATCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATCCCCAATGACAAACCTTTTCAAAACGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Pennsylvania_7_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCCCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAGAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTACCAACGAAAACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATTCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTCCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGGATATCGGGTATAGACCATGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGACAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGGATGTACCAGAGAAACA-------'},\n",
+       "   {'taxon': 'A_Romania_160_1994',\n",
+       "    'sequence': 'CACAAACTTCCCAGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGCTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTTTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATACGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Santiago_7198_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGGACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACATTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGCGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGCTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGACTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTTTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATCCGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAGCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTGAGCCACACACTCTGAAGTTGGCAACAGGGATGCGGTATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Shangdong_5_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTACCAATGAAGGCTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGAATATATGTTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTGAGGGGTATCTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAGACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Singapore_7_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGGCACCATGCGGTGCCAAACGGAACGCTAGTGAAAACAATCGCGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAATTCTTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATACTTGCAAAAGGGGATCTGTTAACGGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGGGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACAGTAATCCCGAGTATCGGGTCTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Thailand_75_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCGGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAATTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATTAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAAAGGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATACCAAACAATGGCAAATCTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGGGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACAGTAATCCCGAGTATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGAATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Vermont_3_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGTAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGCTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTTTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Athens_1_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGACTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCGTATATGTTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCTGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Christchurch_45_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGATAGAATATGCGACAGTCCTCACCAAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTCTGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Cordoba_V185_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTCTGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCAAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAAAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTTAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACT---'},\n",
+       "   {'taxon': 'A_Greece_103_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACTCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTTGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGACAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACCCTGAAATTGGCAACAGGGATGCGGAATGAACCAGAAATAAAACTA---'},\n",
+       "   {'taxon': 'A_JOHANNESBURG_3_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCAGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_MALMO_1_1998',\n",
+       "    'sequence': 'CAAAAAATTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCACTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAGTTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Nagasaki_76_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACACTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAGAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGATCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTCTGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAACATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTATGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Neuquen_V541_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCAAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACT---'},\n",
+       "   {'taxon': 'A_PERTH_24_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAGATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCAGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGCTGCACCAATTAAAATACAAGTATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Pusan_68_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAGTGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTTTGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTTTCCAGCAGAATAAGCATCTATTGGACAATAGTGAAACCGGGAGACATACTTCTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAAGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Seoul_37_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCAGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACAAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Switzerland_7729_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCAGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGAAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Tucuman_V425_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGAAGTCGCTCAGAATGGAACAAGCTCTGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCATATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGATAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTTAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACT---'},\n",
+       "   {'taxon': 'A_Ushuaia_R127_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTCTGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTACTCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACT---'},\n",
+       "   {'taxon': 'A_Waikato_12_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGATAGAATATGCGACAGTCCTCACCAAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTCTGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Czechoslovakia_4_1986',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTATTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAACTGTACATTTGGGGGGTTCACCACCCGATCACGGAAAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTAATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Leningrad_360_1986',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTATTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATACTTGTAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGAAAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCATGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Memphis_6_1986',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCCGTGTCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTAGAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTATTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAACTGTACATTTGGGGGGTTCACCACCCGAGCACGGAAAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Wellington_4_1985',\n",
+       "    'sequence': 'CAAAAACTGCCTGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCTGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGAGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Tonga_23_1985',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAATAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTCTGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACAAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGAGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCTGGAGACATACTGTTGATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'}]},\n",
+       " {'id': 'joint',\n",
+       "  'type': 'JointDistributionModel',\n",
+       "  'distributions': [{'id': 'like',\n",
+       "    'type': 'TreeLikelihoodModel',\n",
+       "    'tree_model': {'id': 'tree',\n",
+       "     'type': 'UnRootedTreeModel',\n",
+       "     'newick': '(((((((((((((((((((((((A_Aichi_69_1994:0.761119957483416,((A_Athens_1_1998:1.77960546386231,(((((A_Christchurch_45_1998:0.18382663880472105,A_Waikato_12_1998:0.18382663880472105):0.36080685757901976,(A_Nagasaki_76_1998:0.4683586942800507,A_Ushuaia_R127_1998:0.4683586942800507):0.07627480210369009):0.07665539949443301,(A_Cordoba_V185_1998:0.42013593002764343,A_Tucuman_V425_1998:0.42013593002764343):0.20115296585053039):0.03328825741009933,((((((A_JOHANNESBURG_3_1998:0.06543681392374098,A_Neuquen_V541_1998:0.06543681392374098):0.12559877256022828,A_Seoul_37_1998:0.19103558648396926):0.02851185075593457,A_Switzerland_7729_1998:0.21954743723990383):0.12370209856431102,A_PERTH_24_1998:0.34324953580421486):0.20173113562224637,A_MALMO_1_1998:0.5449806714264612):0.0574910637513778,A_Pusan_68_1998:0.602471735177839):0.05210541811043412):0.16173751115964685,A_Greece_103_1998:0.81631466444792):0.96329079941439):2.807683231679572,A_Shangdong_5_1994:0.5872886955418819):0.1738312619415341):0.8054851777952443,((((A_Argentina_3779_1994:0.3280215863955993,A_Johannesburg_33_1994:0.3280215863955993):0.05633023389252756,A_HongKong_1_1994:0.38435182028812687):0.1225054221114652,A_England_67_1994:0.5068572423995921):0.3153017874290107,A_Pennsylvania_7_1994:0.8221590298286028):0.7444461054500575):0.1117041564039738,(((A_Akita_1_1994:0.6417587798584359,A_Vermont_3_1994:0.6417587798584359):0.05127233466151093,A_Romania_160_1994:0.6930311145199468):0.47541600449847365,A_Santiago_7198_1994:1.1684471190184205):0.5098621726642136):0.047631087415734186,(A_Singapore_7_1994:1.1305477759728984,A_Thailand_75_1994:1.1305477759728984):0.5953926031254699):0.4338339424951094,A_Harbin_15_1992:0.1597743215934777):0.02629920620920867,A_Sapporo_304_1992:0.18607352780268638):0.1937484748838907,(A_Beijing_32_1992:0.23695409632825193,A_Tianjin_33_1992:0.23695409632825193):0.14286790635832514):0.1591978420861624,A_Alaska_9_1992:0.5390198447727395):0.12628662793003453,A_Hawaii_3_1992:0.665306472702774):0.0842046904371454,((A_California_271_1992:0.451897299281085,A_France_1109_1994:2.451897299281085):0.1572740000983215,A_Qingdao_53_1992:0.6091712993794065):0.14033986376051288):1.0777933630502368,A_Perth_1_1992:1.8273045261901562):0.7301151810754547,(((A_Finland_205_1992:0.13077691856428508,A_Mexico_3255_1994:2.130776918564285):0.443510083848059,A_SouthAustralia_36_1992:0.5742870024123441):0.8306358088764121,((A_Indonesia_3946_1992:0.3229462972945232,A_Umea_1_1992:0.3229462972945232):0.137940246693538,(A_Victoria_29_1992:0.38730776979656234,A_Wellington_66_1992:0.38730776979656234):0.07357877419149883):0.944036267300695):1.1524968959768547):2.9089261572998097,(A_Guangdong_9_1987:0.017198347860013286,A_Sichuan_2_1987:0.017198347860013286):0.4491475167054073):0.10465592148998759,(A_Sydney_1_1987:0.4728837583601262,A_Tokyo_1275_1987:0.4728837583601262):0.098118027695282):0.10660804403484114,A_Victoria_7_1987:0.6776098300902493):0.2830481789149868,(A_Colorado_2_1987:0.6970395797457538,((A_Guizhou_1_1987:0.3294708875986849,A_Qingdao_10_1987:0.3294708875986849):0.14581436538279213,(A_LosAngeles_1987:0.2080843644249839,A_Shanghai_11_1987:0.2080843644249839):0.26720088855649315):0.22175432676427675):0.2636184292594823):1.3960105466893005,((A_Czechoslovakia_4_1986:0.7324724768450999,A_Memphis_6_1986:0.7324724768450999):0.23780269841325996,A_Leningrad_360_1986:0.9702751752583598):0.38639338043617677):0.2954618004514806,(A_Tonga_23_1985:0.5359949423414125,A_Wellington_4_1985:0.5359949423414125):0.11613541380460468):1.5799204291316418,A_Texas_12764_1983:0.232050785277659):0.2731286767267669,A_Alaska_8_1984:1.5051794620044259):0.17177455784891293,((A_Caen_1_1984:1.1478076744720962,A_Oita_3_1983:0.1478076744720962):0.48275071680632564,A_Texas_17988_1984:1.6305583912784218):0.04639562857491697):1.2615765324262416,A_Philippines_2_1982:0.9385305522795804):1.615956610302284,((A_Baylor1B_1983:2.65070571597235,A_ChristHospital_231_1982:1.6507057159723502):0.5244230005194801,A_Belgium_2_1981:1.1751287164918303):0.3793584460900341);',\n",
+       "     'branch_lengths': {'id': 'tree.blens',\n",
+       "      'type': 'Parameter',\n",
+       "      'full': [135],\n",
+       "      'tensor': 0.1,\n",
+       "      'lower': 0.0},\n",
+       "     'taxa': 'taxa'},\n",
+       "    'site_model': {'id': 'sitemodel',\n",
+       "     'type': 'InvariantSiteModel',\n",
+       "     'invariant': {'id': 'sitemodel.pinv',\n",
+       "      'type': 'Parameter',\n",
+       "      'tensor': [0.1],\n",
+       "      'lower': 0,\n",
+       "      'upper': 1}},\n",
+       "    'site_pattern': {'id': 'patterns',\n",
+       "     'type': 'SitePattern',\n",
+       "     'alignment': 'alignment'},\n",
+       "    'substitution_model': {'id': 'substmodel',\n",
+       "     'type': 'GTR',\n",
+       "     'rates': {'id': 'substmodel.rates',\n",
+       "      'type': 'Parameter',\n",
+       "      'full': [6],\n",
+       "      'tensor': 0.16666666666666666,\n",
+       "      'simplex': True},\n",
+       "     'frequencies': {'id': 'substmodel.frequencies',\n",
+       "      'type': 'Parameter',\n",
+       "      'tensor': [0.25, 0.25, 0.25, 0.25],\n",
+       "      'simplex': True}}},\n",
+       "   {'id': 'tree.blens.prior',\n",
+       "    'type': 'Distribution',\n",
+       "    'distribution': 'torch.distributions.Exponential',\n",
+       "    'x': 'tree.blens',\n",
+       "    'parameters': {'rate': 10.0}},\n",
+       "   {'id': 'sitemodel.pinv.prior',\n",
+       "    'type': 'Distribution',\n",
+       "    'distribution': 'torch.distributions.Exponential',\n",
+       "    'x': 'sitemodel.pinv',\n",
+       "    'parameters': {'rate': 2.0}},\n",
+       "   {'id': 'substmodel.frequencies.prior',\n",
+       "    'type': 'Distribution',\n",
+       "    'distribution': 'torch.distributions.Dirichlet',\n",
+       "    'x': 'substmodel.frequencies',\n",
+       "    'parameters': {'concentration': [1.0, 1.0, 1.0, 1.0]}},\n",
+       "   {'id': 'substmodel.rates.prior',\n",
+       "    'type': 'Distribution',\n",
+       "    'distribution': 'torch.distributions.Dirichlet',\n",
+       "    'x': 'substmodel.rates',\n",
+       "    'parameters': {'concentration': [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]}}]}]"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "json_list = []\n",
+    "json_list.append(taxa)\n",
+    "json_list.append(alignment)\n",
+    "json_list.append(joint_dic)\n",
+    "json_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae5b9091",
+   "metadata": {},
+   "source": [
+    "## IV. Variational meanfield distribution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82bd3504",
+   "metadata": {},
+   "source": [
+    "### 1. Variational independent distributions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "94ddabc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var_dist = \"Normal\"\n",
+    "var_id = 'var.' + var_dist"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "c5cd7a7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# convert Parameters with constraints to TransformedParameters\n",
+    "# and create variational distributions\n",
+    "\n",
+    "# TO_DO not use directlly create_meanfield()\n",
+    "var_distributions, var_parameters = create_meanfield(var_id, json_list, var_dist)\n",
+    "\n",
+    "# Jacobian\n",
+    "# I don't think this is useful here\n",
+    "jacobians_list = create_jacobians(json_list)\n",
+    "joint_dic['distributions'].extend(jacobians_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c6dbe56",
+   "metadata": {},
+   "source": [
+    "### 2. Variational joint distribution *Q*()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "e43ef96b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Variational joint distribution\n",
+    "variational = {'id': \"variational\", 'type': 'JointDistributionModel'}\n",
+    "\n",
+    "variational['distributions'] = var_distributions\n",
+    "json_list.append(variational)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d50d231",
+   "metadata": {},
+   "source": [
+    "## V. Fitting the variational model using ADVI\n",
+    "\n",
+    "### 1. Automatic Differentiation Variational Inference (ADVI)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "3a6bae45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Hyperparams\n",
+    "lr = 0.1\n",
+    "iterations = 100000\n",
+    "grad_samples = 1\n",
+    "convergence_every = 100\n",
+    "elbo_samples = 100\n",
+    "tol_rel_obj = 0.01"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "b13c5ebe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize optimizer\n",
+    "advi_dic = {\n",
+    "    'id': 'advi',\n",
+    "    'type': 'Optimizer',\n",
+    "    'algorithm': 'torch.optim.Adam',\n",
+    "    'options': {'lr': lr},\n",
+    "    'maximize': True,\n",
+    "    'checkpoint': checkpoint_file,\n",
+    "    'iterations': iterations,\n",
+    "    'loss': {\n",
+    "        'id': 'elbo',\n",
+    "        'type': 'ELBO',\n",
+    "        'samples': grad_samples,\n",
+    "        'joint': 'joint', \n",
+    "        'variational': 'variational',\n",
+    "        },\n",
+    "    'parameters': var_parameters,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "6ea76c60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize convergence\n",
+    "advi_dic['convergence'] = {\n",
+    "    'type': 'StanVariationalConvergence',\n",
+    "    'max_iterations': iterations,\n",
+    "    'loss': 'elbo',\n",
+    "    'every': convergence_every,\n",
+    "    'samples': elbo_samples,\n",
+    "    'tol_rel_obj': tol_rel_obj,\n",
+    "    }\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "18a9f4f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize scheduler\n",
+    "advi_dic['scheduler'] = {\n",
+    "    'type': 'torchtree.optim.Scheduler',\n",
+    "    'scheduler': 'torch.optim.lr_scheduler.LambdaLR',\n",
+    "    'lr_lambda': 'lambda epoch: 1.0 / (epoch + 1)**0.5',\n",
+    "}\n",
+    "\n",
+    "json_list.append(advi_dic)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "5eca0133",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'id': 'taxa',\n",
+       "  'type': 'Taxa',\n",
+       "  'taxa': [{'id': 'A_Belgium_2_1981', 'type': 'Taxon'},\n",
+       "   {'id': 'A_ChristHospital_231_1982', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Philippines_2_1982', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Baylor1B_1983', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Oita_3_1983', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Texas_12764_1983', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Alaska_8_1984', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Caen_1_1984', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Texas_17988_1984', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Colorado_2_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Guangdong_9_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Guizhou_1_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_LosAngeles_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Qingdao_10_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Shanghai_11_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Sichuan_2_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Sydney_1_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Tokyo_1275_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Victoria_7_1987', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Alaska_9_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Beijing_32_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_California_271_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Finland_205_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Harbin_15_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Hawaii_3_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Indonesia_3946_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Perth_1_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Qingdao_53_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Sapporo_304_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_SouthAustralia_36_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Tianjin_33_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Umea_1_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Victoria_29_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Wellington_66_1992', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Aichi_69_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Akita_1_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Argentina_3779_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_England_67_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_France_1109_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_HongKong_1_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Johannesburg_33_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Mexico_3255_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Pennsylvania_7_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Romania_160_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Santiago_7198_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Shangdong_5_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Singapore_7_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Thailand_75_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Vermont_3_1994', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Athens_1_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Christchurch_45_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Cordoba_V185_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Greece_103_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_JOHANNESBURG_3_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_MALMO_1_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Nagasaki_76_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Neuquen_V541_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_PERTH_24_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Pusan_68_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Seoul_37_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Switzerland_7729_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Tucuman_V425_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Ushuaia_R127_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Waikato_12_1998', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Czechoslovakia_4_1986', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Leningrad_360_1986', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Memphis_6_1986', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Wellington_4_1985', 'type': 'Taxon'},\n",
+       "   {'id': 'A_Tonga_23_1985', 'type': 'Taxon'}]},\n",
+       " {'id': 'alignment',\n",
+       "  'type': 'Alignment',\n",
+       "  'datatype': {'id': 'data_type', 'type': 'NucleotideDataType'},\n",
+       "  'taxa': 'taxa',\n",
+       "  'sequences': [{'taxon': 'A_Belgium_2_1981',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCATCGGATCCTTGATGGGAAAAACTGCACACTGGTAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTTCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCGTCAGGCACCCTGGAGTTTATCAATGAAAGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGATAAAAGTTTCTTCAGTAGACTGAATTGGTTGTACGAATCAGAAAGCAGATATCCAGTGCTGAACGTGACTATGCCAAACAATGGCAATTTTGACAAACTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTATAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTAATTAATAGTAATGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATGCGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAGCCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAAGTATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_ChristHospital_231_1982',\n",
+       "    'sequence': 'CAAAACCTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAAAATATGCGGCAGTCCTCACCGAATCCTTGATGGGAAAAACTGCACACTGGTAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTCTCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCGTCAGGCACCCTGGAGTTTATCAATGAAAGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGATAACAGTTTCTTCAGTAGACTGAATTGGTTGTATGAATCAGAAAGCAAATATCCAGTGCTGAACGTGACTATGCCAAACAATGGCAATTTTGACAAACTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAAACTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAACCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGCTAATTAATAGTAATGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAGCCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAAGTATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAAAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Philippines_2_1982',\n",
+       "    'sequence': 'CAAAACCTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGGATATGCGACAGTCCTCACCGAATCCTTGATGGGAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATACTTGCAAAAGGGGATCTAATAACAGTTTCTTCAGTAGACTGAACTGGTTGTACGAATCAGAAAGCAAATATCCAGTGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGATTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATATTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGTATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTAATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAGCCCTTTCAAAACGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Baylor1B_1983',\n",
+       "    'sequence': 'CAAAACCTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGGAAAAACTGCACACTGGTAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTTCAAAATGAGAAATGGGACCTTTTTATTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCGTCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGATAACAGTTTCTTCAGTAGACTGAATTGGTTGTACGAATCAGAAAGCAAATATCCAGTGCTGAACGTGACTATGCCAAACAATGGCAATTTTGACAAACTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAACCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGCTAATTAATAGTAATGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAGCCCTTTCAAAATGTAAACAAGATCACATATGGGACATGTCCTAAATACGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Oita_3_1983',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGGAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACAAATCAGAAAGCAAATATCCAGTGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGCAGAATAAGTATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTAATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Texas_12764_1983',\n",
+       "    'sequence': 'CAAAACCTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACGAATCAGAAAGCAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATTACATATGGGGCATGTCCCAGGTATGTTAAACAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Alaska_8_1984',\n",
+       "    'sequence': '---AAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTACCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACGAGTCAGAAAGCAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGATCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGCCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGTATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTAATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCTGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Caen_1_1984',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGGAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAACGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACAAATCAGAAAGCAAATATCCAGTGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGTATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTAATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTATGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Texas_17988_1984',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGCTCTTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGGAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGTCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAATTTACCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACGAATCAGAAAGCAAATATCCAGTGCTGAACGTGAGTATGCCAAACAATGGCAAATTAGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGTACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGTATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTAATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCGAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Colorado_2_1987',\n",
+       "    'sequence': 'CAAAAACTTCCTGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACTCTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGTATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAAACTATATGTTCGAGCATCAGGAAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Guangdong_9_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGGTCACGGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Guizhou_1_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTCCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGGGTGGGGGAAGCTATTCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGAATCAGAATGCAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAGCTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_LosAngeles_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGATCACGGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Qingdao_10_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATTCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGCCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Shanghai_11_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGAACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Sichuan_2_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGGTCACGGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Sydney_1_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAGGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATTCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAAACTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Tokyo_1275_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTATAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAGGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATACTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATCTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACTGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGAGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Victoria_7_1987',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATTCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Alaska_9_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCAAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATTCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Beijing_32_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCTTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_California_271_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGAAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTTTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Finland_205_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAGAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGTGACAGTCCTCACCGAATCCTTGATGGAAAAAATTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTACCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGAGTGGGGAAAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACRAATCAGATTACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCCACCAAAAGAAGCCAACAAACTGTGATCCCGAATATCGGGTCCAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTGAAACCGGGAGACATACTTTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGAACTGGGAAAAGCTCGATAATGAGATCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAACGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACT---'},\n",
+       "   {'taxon': 'A_Harbin_15_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTACAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGATCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Hawaii_3_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCCCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCGCTAAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Indonesia_3946_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGGCATCATGCAGTGCCAAACGGAACTCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTCGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGACTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAATTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGAGTGGGGACAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCATCGCTGAACGTGACTATGCCAAACAATGACAAATTTGACAAGTTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAGCCTATATATTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTCCAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACCGGGAATCTAATTGCTCCACGGGGTTACTTCAAAATACGAACTGGGAAAAGCTCGATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATCCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Perth_1_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTATGCCTGGGACATCATGCAGTGCCAAATGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATAGCTTCCAAAACAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAAGTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCATCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Qingdao_53_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGAAGTCGCTCAGGATGGGGGAAGCTGTGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCCGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Sapporo_304_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGTTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_SouthAustralia_36_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGTGACAGTCCTCACCGAATCCTTGATGGAAAAAATTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTACCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGAGTGGGGAAAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACGAATCAGATTACAAATACCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCCACCAAAAGAAGCCAACAAACTGTGATCCCGAATATCGGGTCCAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGAACTGGGAAAAGCTCGATAATGAGATCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATCCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGAATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Tianjin_33_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCAGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATCAGAATACAAATATCCAGCTCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Umea_1_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGGCATCATGCAGTGCCAAACGGAACTCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAAAATATGCGACAGTCCTCACCGAATCCTCGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGACTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAATTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGAGTGGGGACAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGACAAATTTGACAAGTTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAGCCTATATATTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGTCAACAAACTGTAATCCCAAATATCGGGTCCAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACCGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAACTGGGAAAAGCTCGATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATCCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Victoria_29_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTATGCCTGGGGCATCATGCAGTGCCAAACGGAACTCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTCGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAATTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGAATGGGGGCAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAACGACAAATTTGACAAGTTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAGCCTATATATTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTCCAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACCGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGGACTGGGAAAAGCTCGATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATCCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGAATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Wellington_66_1992',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGGCATCATGCAGTGCCAAACGGAACTCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTCCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTCGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAATTGTTACCCTTATGATGTGCCAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCCCTCAGAATGGGGACAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACGAATCAGAATACAAATATCCAACGCTGAACGTGACTATGCCAAACAATGACAAATTTGACAAGTTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAGCCTATATATTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTCCAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACCGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGGACTGGGAAAAGCTCGATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATCCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Aichi_69_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGACTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTACCAATGAAGGCTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTATCTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGGTTAACAGCACAGGGAATCTAATTGCTCCTCGAGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGATCAGATGCACCCATTGACAACTGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACT---'},\n",
+       "   {'taxon': 'A_Akita_1_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAGAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGCTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTTTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATTTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACT---'},\n",
+       "   {'taxon': 'A_Argentina_3779_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCCCAACAGGTAGAATATGCGACAGCCCTCACCGAATCCTTGATGGAAAGAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAACGAAAACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCACACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGTCCAAACCAGCCTATATGTCCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGGATATCGGGTATAGACCATGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCCAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGGAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_England_67_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCCCAACAGGTAGAATATGCAACAGTCCTCACCGAATCCTTGATGGAAAGAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGACTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAACGAAAACTTCAATTGGACCGGAGTCGCTCAGGATGGGAAAAGCTATACTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTCCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGGATATCGGGTATAGACCATGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTTAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCATCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_France_1109_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACAGAATCCTTGATGGGAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTAATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTACCAATGAGGACTTCAATTGGACTGGAGTCGCTCAGGATGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACTAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAACCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGAAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATACGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_HongKong_1_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCCCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAGAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAACGAAAACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTCCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGGATATCGGGTATAGACCATGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTCTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATTATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Johannesburg_33_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCCCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAGAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAACGAAAACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTCCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGGATATCGGGTATAGACCATGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Mexico_3255_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGTGACAGTCCTCACCGAATCCTTGATGGAAAAAATTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGATCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGAGTGGGGAAAGCTATGCTTGCAAAAGGGGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACGAATCAGATTACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGAGAACAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCCACCAAAAGAAGCCAACAAACTGTGATCCCGAATATCGGGTCCAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTGAAACCGGGAGACATACTTTTGATTAATAGCACCGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGAACTGGGAAAAGCTCGATAATGAGATCAGATGCACCCATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATCCCCAATGACAAACCTTTTCAAAACGTAAACAGGATCACATATGGGGCATGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Pennsylvania_7_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCCCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAGAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTACCAACGAAAACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATTCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTCCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGGATATCGGGTATAGACCATGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGACAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGGATGTACCAGAGAAACA-------'},\n",
+       "   {'taxon': 'A_Romania_160_1994',\n",
+       "    'sequence': 'CACAAACTTCCCAGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGCTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTTTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATACGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Santiago_7198_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGGACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACATTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGCGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGCTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGACTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTTTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATCCGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAGCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTGAGCCACACACTCTGAAGTTGGCAACAGGGATGCGGTATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Shangdong_5_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTACCAATGAAGGCTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGAATATATGTTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTGAGGGGTATCTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAGACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Singapore_7_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGGCACCATGCGGTGCCAAACGGAACGCTAGTGAAAACAATCGCGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAATTCTTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATACTTGCAAAAGGGGATCTGTTAACGGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGGGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACAGTAATCCCGAGTATCGGGTCTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Thailand_75_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCGGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAATTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATTAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAAAGGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATACCAAACAATGGCAAATCTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGGGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACAGTAATCCCGAGTATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGAATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Vermont_3_1994',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGTAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGACTTCAATTGGACTGGAGTCGCTCAGGATGGGAAAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTTAGTAGATTGAATTGGCTGCACAAATTAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAGTGACCAAACCAGCCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGGTTTAGACCCTGGGTAAGGGGTCAGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAATAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAATGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCTTTTCAAAATGTAAACAGGATCACATATGGGGCCTGCCCCAGATATGTTAAGCAAAACACTCTGAAGTTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Athens_1_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGACTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTGTTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACAAATTAGAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCGTATATGTTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCTGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAACTGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Christchurch_45_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGATAGAATATGCGACAGTCCTCACCAAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTCTGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Cordoba_V185_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTCTGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCAAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAAAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTTAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACT---'},\n",
+       "   {'taxon': 'A_Greece_103_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACTCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTTGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGACAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACCCTGAAATTGGCAACAGGGATGCGGAATGAACCAGAAATAAAACTA---'},\n",
+       "   {'taxon': 'A_JOHANNESBURG_3_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCAGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_MALMO_1_1998',\n",
+       "    'sequence': 'CAAAAAATTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCACTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAGTTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Nagasaki_76_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACACTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAGAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGATCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTCTGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAACATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTATGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Neuquen_V541_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCAAGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACT---'},\n",
+       "   {'taxon': 'A_PERTH_24_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAGATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCAGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGCTGCACCAATTAAAATACAAGTATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Pusan_68_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAGTGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTTTGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTTTCCAGCAGAATAAGCATCTATTGGACAATAGTGAAACCGGGAGACATACTTCTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAAGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Seoul_37_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCAGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACAAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Switzerland_7729_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCAGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGAAGTCGCTCAGAATGGAACAAGCTATGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Tucuman_V425_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGAAGTCGCTCAGAATGGAACAAGCTCTGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCATATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGATAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTTAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACT---'},\n",
+       "   {'taxon': 'A_Ushuaia_R127_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTCTGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTACTCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACT---'},\n",
+       "   {'taxon': 'A_Waikato_12_1998',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACGGCAACGCTGTGCCTGGGACACCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGACCAAATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGATAGAATATGCGACAGTCCTCACCAAATCCTTGATGGAGAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATAAGGAATGGGACCTTTTTGTTGAACGCAGCAAAGCCTACAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCCGGCACCCTGGAGTTTAACAATGAAAGCTTCAATTGGACTGGAGTCGCTCAGAATGGAACAAGCTCTGCTTGCAAAAGGAGATCTATTAAAAGTTTCTTTAGTAGATTGAATTGGTTGCACCAATTAAAATACAAATATCCAGCACTGAACGTGACTATGCCAAACAATGACAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGTACGGACAGTGACCAAACCAGCCTATATGCTCAAGCATCAGGGAGAGTCACAGTCTCTACCAAAAGAAGCCAACAAACTGTAATCCCGAATATCGGATCTAGACCCTGGGTAAGGGGTGTCTCCAGCAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTTTTGATTAACAGCACAGGGAATCTAATTGCTCCTCGGGGTTACTTCAAAATACGAAGTGGGAAAAGCTCAATAATGAGGTCAGATGCACCCATTGGCAAATGCAATTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCATTTCAAAATGTAAACAGGATCACATATGGGGCCTGTCCCAGATATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Czechoslovakia_4_1986',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTATTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAACTGTACATTTGGGGGGTTCACCACCCGATCACGGAAAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTAATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Leningrad_360_1986',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTATTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATACTTGTAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGAAAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCATGGGTAAGGGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Memphis_6_1986',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCCGTGTCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTAGAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTATTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAACTGTACATTTGGGGGGTTCACCACCCGAGCACGGAAAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGGGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Wellington_4_1985',\n",
+       "    'sequence': 'CAAAAACTGCCTGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAACAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCTGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTATGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACGAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGAGGTCTGTCCAGTAGAATAAGCATCTATTGGACAATAGTAAAACCGGGAGACATACTGTTGATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'},\n",
+       "   {'taxon': 'A_Tonga_23_1985',\n",
+       "    'sequence': 'CAAAAACTTCCCGGAAATGACAACAGCACAGCAACGCTGTGCCTGGGACATCATGCAGTGCCAAACGGAACGCTAGTGAAAACAATCACGAATGATCAGATTGAAGTGACTAATGCTACTGAGCTGGTTCAGAGTTCCTCAATAGGTAGAATATGCGACAGTCCTCACCGAATCCTTGATGGAAAAAACTGCACACTGATAGATGCTCTATTGGGAGACCCTCATTGTGATGGCTTCCAAAATGAGAAATGGGACCTTTTTGTTGAACGCAGCAAAGCTTTCAGCAACTGTTACCCTTATGATGTGCCGGATTATGCCTCCCTTAGGTCACTAGTTGCCTCATCAGGCACCCTGGAGTTTATCAATGAAGGCTTCAATTGGACTGGAGTCACTCAGAGTGGGGGAAGCTCTGCTTGCAAAAGGGGATCTGTTAACAGTTTCTTCAGTAGATTGAATTGGTTGTACAAATCAGAATACAAATATCCAGCGCTGAACGTGACTATGCCAAACAATGGCAAATTTGACAAATTGTACATTTGGGGGGTTCACCACCCGAGCACGGACAAAGAACAAACCAACCTATATGTTCGAGCATCAGGGAGAGTCACAGTCTCTACCAAGAGAAGCCAGCAAACTGTAATCCCGAATATCGGGTCTAGACCCTGGGTAAGAGGTCTGTCTAGTAGAATAAGCATCTATTGGACAATAGTAAAACCTGGAGACATACTGTTGATTAATAGCACTGGGAACCTAATTGCTCCTCGGGGTTACTTCAAAATACGCACTGGGAAAAGCTCAATAATGAGGTCAGATGCACCTATTGGCACCTGCAGTTCTGAATGCATCACTCCAAATGGAAGCATTCCCAATGACAAACCCTTTCAAAATGTAAACAAGATCACATATGGGGCATGTCCCAGGTATGTTAAGCAAAACACTCTGAAATTGGCAACAGGGATGCGGAATGTACCAGAGAAACAAACTAGA'}]},\n",
+       " {'id': 'joint',\n",
+       "  'type': 'JointDistributionModel',\n",
+       "  'distributions': [{'id': 'like',\n",
+       "    'type': 'TreeLikelihoodModel',\n",
+       "    'tree_model': {'id': 'tree',\n",
+       "     'type': 'UnRootedTreeModel',\n",
+       "     'newick': '(((((((((((((((((((((((A_Aichi_69_1994:0.761119957483416,((A_Athens_1_1998:1.77960546386231,(((((A_Christchurch_45_1998:0.18382663880472105,A_Waikato_12_1998:0.18382663880472105):0.36080685757901976,(A_Nagasaki_76_1998:0.4683586942800507,A_Ushuaia_R127_1998:0.4683586942800507):0.07627480210369009):0.07665539949443301,(A_Cordoba_V185_1998:0.42013593002764343,A_Tucuman_V425_1998:0.42013593002764343):0.20115296585053039):0.03328825741009933,((((((A_JOHANNESBURG_3_1998:0.06543681392374098,A_Neuquen_V541_1998:0.06543681392374098):0.12559877256022828,A_Seoul_37_1998:0.19103558648396926):0.02851185075593457,A_Switzerland_7729_1998:0.21954743723990383):0.12370209856431102,A_PERTH_24_1998:0.34324953580421486):0.20173113562224637,A_MALMO_1_1998:0.5449806714264612):0.0574910637513778,A_Pusan_68_1998:0.602471735177839):0.05210541811043412):0.16173751115964685,A_Greece_103_1998:0.81631466444792):0.96329079941439):2.807683231679572,A_Shangdong_5_1994:0.5872886955418819):0.1738312619415341):0.8054851777952443,((((A_Argentina_3779_1994:0.3280215863955993,A_Johannesburg_33_1994:0.3280215863955993):0.05633023389252756,A_HongKong_1_1994:0.38435182028812687):0.1225054221114652,A_England_67_1994:0.5068572423995921):0.3153017874290107,A_Pennsylvania_7_1994:0.8221590298286028):0.7444461054500575):0.1117041564039738,(((A_Akita_1_1994:0.6417587798584359,A_Vermont_3_1994:0.6417587798584359):0.05127233466151093,A_Romania_160_1994:0.6930311145199468):0.47541600449847365,A_Santiago_7198_1994:1.1684471190184205):0.5098621726642136):0.047631087415734186,(A_Singapore_7_1994:1.1305477759728984,A_Thailand_75_1994:1.1305477759728984):0.5953926031254699):0.4338339424951094,A_Harbin_15_1992:0.1597743215934777):0.02629920620920867,A_Sapporo_304_1992:0.18607352780268638):0.1937484748838907,(A_Beijing_32_1992:0.23695409632825193,A_Tianjin_33_1992:0.23695409632825193):0.14286790635832514):0.1591978420861624,A_Alaska_9_1992:0.5390198447727395):0.12628662793003453,A_Hawaii_3_1992:0.665306472702774):0.0842046904371454,((A_California_271_1992:0.451897299281085,A_France_1109_1994:2.451897299281085):0.1572740000983215,A_Qingdao_53_1992:0.6091712993794065):0.14033986376051288):1.0777933630502368,A_Perth_1_1992:1.8273045261901562):0.7301151810754547,(((A_Finland_205_1992:0.13077691856428508,A_Mexico_3255_1994:2.130776918564285):0.443510083848059,A_SouthAustralia_36_1992:0.5742870024123441):0.8306358088764121,((A_Indonesia_3946_1992:0.3229462972945232,A_Umea_1_1992:0.3229462972945232):0.137940246693538,(A_Victoria_29_1992:0.38730776979656234,A_Wellington_66_1992:0.38730776979656234):0.07357877419149883):0.944036267300695):1.1524968959768547):2.9089261572998097,(A_Guangdong_9_1987:0.017198347860013286,A_Sichuan_2_1987:0.017198347860013286):0.4491475167054073):0.10465592148998759,(A_Sydney_1_1987:0.4728837583601262,A_Tokyo_1275_1987:0.4728837583601262):0.098118027695282):0.10660804403484114,A_Victoria_7_1987:0.6776098300902493):0.2830481789149868,(A_Colorado_2_1987:0.6970395797457538,((A_Guizhou_1_1987:0.3294708875986849,A_Qingdao_10_1987:0.3294708875986849):0.14581436538279213,(A_LosAngeles_1987:0.2080843644249839,A_Shanghai_11_1987:0.2080843644249839):0.26720088855649315):0.22175432676427675):0.2636184292594823):1.3960105466893005,((A_Czechoslovakia_4_1986:0.7324724768450999,A_Memphis_6_1986:0.7324724768450999):0.23780269841325996,A_Leningrad_360_1986:0.9702751752583598):0.38639338043617677):0.2954618004514806,(A_Tonga_23_1985:0.5359949423414125,A_Wellington_4_1985:0.5359949423414125):0.11613541380460468):1.5799204291316418,A_Texas_12764_1983:0.232050785277659):0.2731286767267669,A_Alaska_8_1984:1.5051794620044259):0.17177455784891293,((A_Caen_1_1984:1.1478076744720962,A_Oita_3_1983:0.1478076744720962):0.48275071680632564,A_Texas_17988_1984:1.6305583912784218):0.04639562857491697):1.2615765324262416,A_Philippines_2_1982:0.9385305522795804):1.615956610302284,((A_Baylor1B_1983:2.65070571597235,A_ChristHospital_231_1982:1.6507057159723502):0.5244230005194801,A_Belgium_2_1981:1.1751287164918303):0.3793584460900341);',\n",
+       "     'branch_lengths': {'id': 'tree.blens',\n",
+       "      'type': 'TransformedParameter',\n",
+       "      'lower': 0.0,\n",
+       "      'transform': 'torch.distributions.ExpTransform',\n",
+       "      'x': {'id': 'tree.blens.unres',\n",
+       "       'type': 'Parameter',\n",
+       "       'tensor': -2.3025850929940455,\n",
+       "       'full': [135]}},\n",
+       "     'taxa': 'taxa'},\n",
+       "    'site_model': {'id': 'sitemodel',\n",
+       "     'type': 'InvariantSiteModel',\n",
+       "     'invariant': {'id': 'sitemodel.pinv',\n",
+       "      'type': 'TransformedParameter',\n",
+       "      'lower': 0,\n",
+       "      'upper': 1,\n",
+       "      'transform': 'torch.distributions.SigmoidTransform',\n",
+       "      'x': {'id': 'sitemodel.pinv.unres',\n",
+       "       'type': 'Parameter',\n",
+       "       'tensor': [-2.1972246170043945]}}},\n",
+       "    'site_pattern': {'id': 'patterns',\n",
+       "     'type': 'SitePattern',\n",
+       "     'alignment': 'alignment'},\n",
+       "    'substitution_model': {'id': 'substmodel',\n",
+       "     'type': 'GTR',\n",
+       "     'rates': {'id': 'substmodel.rates',\n",
+       "      'type': 'TransformedParameter',\n",
+       "      'simplex': True,\n",
+       "      'transform': 'torch.distributions.StickBreakingTransform',\n",
+       "      'x': {'id': 'substmodel.rates.unres',\n",
+       "       'type': 'Parameter',\n",
+       "       'tensor': 0.0,\n",
+       "       'full': [5]}},\n",
+       "     'frequencies': {'id': 'substmodel.frequencies',\n",
+       "      'type': 'TransformedParameter',\n",
+       "      'simplex': True,\n",
+       "      'transform': 'torch.distributions.StickBreakingTransform',\n",
+       "      'x': {'id': 'substmodel.frequencies.unres',\n",
+       "       'type': 'Parameter',\n",
+       "       'tensor': [0.0, 0.0, 0.0]}}}},\n",
+       "   {'id': 'tree.blens.prior',\n",
+       "    'type': 'Distribution',\n",
+       "    'distribution': 'torch.distributions.Exponential',\n",
+       "    'x': 'tree.blens',\n",
+       "    'parameters': {'rate': 10.0}},\n",
+       "   {'id': 'sitemodel.pinv.prior',\n",
+       "    'type': 'Distribution',\n",
+       "    'distribution': 'torch.distributions.Exponential',\n",
+       "    'x': 'sitemodel.pinv',\n",
+       "    'parameters': {'rate': 2.0}},\n",
+       "   {'id': 'substmodel.frequencies.prior',\n",
+       "    'type': 'Distribution',\n",
+       "    'distribution': 'torch.distributions.Dirichlet',\n",
+       "    'x': 'substmodel.frequencies',\n",
+       "    'parameters': {'concentration': [1.0, 1.0, 1.0, 1.0]}},\n",
+       "   {'id': 'substmodel.rates.prior',\n",
+       "    'type': 'Distribution',\n",
+       "    'distribution': 'torch.distributions.Dirichlet',\n",
+       "    'x': 'substmodel.rates',\n",
+       "    'parameters': {'concentration': [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]}},\n",
+       "   'tree.blens',\n",
+       "   'sitemodel.pinv',\n",
+       "   'substmodel.rates',\n",
+       "   'substmodel.frequencies']},\n",
+       " {'id': 'variational',\n",
+       "  'type': 'JointDistributionModel',\n",
+       "  'distributions': [{'id': 'var.Normal.tree.blens',\n",
+       "    'type': 'Distribution',\n",
+       "    'distribution': 'torch.distributions.Normal',\n",
+       "    'x': 'tree.blens.unres',\n",
+       "    'parameters': {'loc': {'id': 'var.Normal.tree.blens.unres.loc',\n",
+       "      'type': 'Parameter',\n",
+       "      'full_like': 'tree.blens.unres',\n",
+       "      'tensor': -2.3502401828962083},\n",
+       "     'scale': {'id': 'var.Normal.tree.blens.unres.scale',\n",
+       "      'type': 'TransformedParameter',\n",
+       "      'transform': 'torch.distributions.ExpTransform',\n",
+       "      'x': {'id': 'var.Normal.tree.blens.unres.scale.unres',\n",
+       "       'type': 'Parameter',\n",
+       "       'full_like': 'tree.blens.unres',\n",
+       "       'tensor': -1.1753093277566469}}}},\n",
+       "   {'id': 'var.Normal.sitemodel.pinv.unres',\n",
+       "    'type': 'Distribution',\n",
+       "    'distribution': 'torch.distributions.Normal',\n",
+       "    'x': 'sitemodel.pinv.unres',\n",
+       "    'parameters': {'loc': {'id': 'var.Normal.sitemodel.pinv.unres.loc',\n",
+       "      'type': 'Parameter',\n",
+       "      'tensor': [-2.1972246170043945]},\n",
+       "     'scale': {'id': 'var.Normal.sitemodel.pinv.unres.scale',\n",
+       "      'type': 'TransformedParameter',\n",
+       "      'transform': 'torch.distributions.ExpTransform',\n",
+       "      'x': {'id': 'var.Normal.sitemodel.pinv.unres.scale.unres',\n",
+       "       'type': 'Parameter',\n",
+       "       'full_like': 'sitemodel.pinv.unres',\n",
+       "       'tensor': -1.89712}}}},\n",
+       "   {'id': 'var.Normal.substmodel.rates',\n",
+       "    'type': 'Distribution',\n",
+       "    'distribution': 'torch.distributions.Normal',\n",
+       "    'x': 'substmodel.rates.unres',\n",
+       "    'parameters': {'loc': {'id': 'var.Normal.substmodel.rates.unres.loc',\n",
+       "      'type': 'Parameter',\n",
+       "      'full_like': 'substmodel.rates.unres',\n",
+       "      'tensor': 0.5},\n",
+       "     'scale': {'id': 'var.Normal.substmodel.rates.unres.scale',\n",
+       "      'type': 'TransformedParameter',\n",
+       "      'transform': 'torch.distributions.ExpTransform',\n",
+       "      'x': {'id': 'var.Normal.substmodel.rates.unres.scale.unres',\n",
+       "       'type': 'Parameter',\n",
+       "       'full_like': 'substmodel.rates.unres',\n",
+       "       'tensor': -1.89712}}}},\n",
+       "   {'id': 'var.Normal.substmodel.frequencies',\n",
+       "    'type': 'Distribution',\n",
+       "    'distribution': 'torch.distributions.Normal',\n",
+       "    'x': 'substmodel.frequencies.unres',\n",
+       "    'parameters': {'loc': {'id': 'var.Normal.substmodel.frequencies.unres.loc',\n",
+       "      'type': 'Parameter',\n",
+       "      'full_like': 'substmodel.frequencies.unres',\n",
+       "      'tensor': 0.5},\n",
+       "     'scale': {'id': 'var.Normal.substmodel.frequencies.unres.scale',\n",
+       "      'type': 'TransformedParameter',\n",
+       "      'transform': 'torch.distributions.ExpTransform',\n",
+       "      'x': {'id': 'var.Normal.substmodel.frequencies.unres.scale.unres',\n",
+       "       'type': 'Parameter',\n",
+       "       'full_like': 'substmodel.frequencies.unres',\n",
+       "       'tensor': -1.89712}}}}]},\n",
+       " {'id': 'advi',\n",
+       "  'type': 'Optimizer',\n",
+       "  'algorithm': 'torch.optim.Adam',\n",
+       "  'options': {'lr': 0.1},\n",
+       "  'maximize': True,\n",
+       "  'checkpoint': 'fluA_checkpoint.json',\n",
+       "  'iterations': 100000,\n",
+       "  'loss': {'id': 'elbo',\n",
+       "   'type': 'ELBO',\n",
+       "   'samples': 1,\n",
+       "   'joint': 'joint',\n",
+       "   'variational': 'variational'},\n",
+       "  'parameters': ['var.Normal.tree.blens.unres.loc',\n",
+       "   'var.Normal.tree.blens.unres.scale.unres',\n",
+       "   'var.Normal.sitemodel.pinv.unres.loc',\n",
+       "   'var.Normal.sitemodel.pinv.unres.scale.unres',\n",
+       "   'var.Normal.substmodel.rates.unres.loc',\n",
+       "   'var.Normal.substmodel.rates.unres.scale.unres',\n",
+       "   'var.Normal.substmodel.frequencies.unres.loc',\n",
+       "   'var.Normal.substmodel.frequencies.unres.scale.unres'],\n",
+       "  'convergence': {'type': 'StanVariationalConvergence',\n",
+       "   'max_iterations': 100000,\n",
+       "   'loss': 'elbo',\n",
+       "   'every': 100,\n",
+       "   'samples': 100,\n",
+       "   'tol_rel_obj': 0.01},\n",
+       "  'scheduler': {'type': 'torchtree.optim.Scheduler',\n",
+       "   'scheduler': 'torch.optim.lr_scheduler.LambdaLR',\n",
+       "   'lr_lambda': 'lambda epoch: 1.0 / (epoch + 1)**0.5'}}]"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "json_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e242004a",
+   "metadata": {},
+   "source": [
+    "### 2. Sampler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "294502f2",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': 'sampler',\n",
+       " 'type': 'Sampler',\n",
+       " 'model': 'variational',\n",
+       " 'samples': 1000,\n",
+       " 'loggers': [{'id': 'logger',\n",
+       "   'type': 'Logger',\n",
+       "   'file_name': 'fluA_samples.csv',\n",
+       "   'parameters': ['joint',\n",
+       "    'like',\n",
+       "    'variational',\n",
+       "    'tree.blens',\n",
+       "    'substmodel.rates',\n",
+       "    'substmodel.frequencies',\n",
+       "    'sitemodel.pinv'],\n",
+       "   'delimiter': '\\t'},\n",
+       "  {'id': 'tree.logger',\n",
+       "   'type': 'TreeLogger',\n",
+       "   'file_name': 'fluA_samples.trees',\n",
+       "   'tree_model': 'tree'}]}"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "parameters = [\n",
+    "    'tree.blens', \n",
+    "    \"substmodel.rates\", \n",
+    "    \"substmodel.frequencies\", \n",
+    "    \"sitemodel.pinv\"\n",
+    "]\n",
+    "\n",
+    "samples = 1000\n",
+    "\n",
+    "sampler = {\n",
+    "    \"id\": 'sampler',\n",
+    "    \"type\": \"Sampler\",\n",
+    "    \"model\": 'variational',\n",
+    "    \"samples\": samples,\n",
+    "    \"loggers\": [\n",
+    "        {\n",
+    "            \"id\": \"logger\",\n",
+    "            \"type\": \"Logger\",\n",
+    "            \"file_name\": file_sample_name,\n",
+    "            \"parameters\": ['joint', 'like', 'variational'] + parameters,\n",
+    "            \"delimiter\": \"\\t\",\n",
+    "        },\n",
+    "        {\n",
+    "            \"id\": \"tree.logger\",\n",
+    "            \"type\": \"TreeLogger\",\n",
+    "            \"file_name\": tree_file_name,\n",
+    "            \"tree_model\": \"tree\",\n",
+    "        },\n",
+    "    ],\n",
+    "}\n",
+    "\n",
+    "sampler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "5d2028c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_list.append(sampler)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9b8e833",
+   "metadata": {},
+   "source": [
+    "### 3. Create json file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "b0bd1da1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create json file\n",
+    "\n",
+    "with open(json_outfile, \"w\") as fh:\n",
+    "    dump(json_list, fh, indent=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b480e51",
+   "metadata": {},
+   "source": [
+    "### 4. Run torchtree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "62fd19e4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SEED: 2582957386847507338\n",
+      "dtype: torch.float64\n",
+      "\n",
+      "  iter             ELBO   delta_ELBO_mean   delta_ELBO_med   notes \n",
+      "     0        -8189.801             1.000            1.000\n",
+      "   100        -5312.984             0.771            0.771\n",
+      "   200        -4998.764             0.535            0.541\n",
+      "   300        -4852.789             0.409            0.302\n",
+      "   400        -4766.674             0.330            0.063\n",
+      "   500        -4718.430             0.277            0.046\n",
+      "   600        -4683.129             0.239            0.030\n",
+      "   700        -4659.274             0.209            0.024\n",
+      "   800        -4642.069             0.187            0.018\n",
+      "   900        -4629.355             0.168            0.014\n",
+      "  1000        -4619.499             0.153            0.010\n",
+      "  1100        -4610.929             0.140            0.009   MEDIAN ELBO CONVERGED\n"
+     ]
+    }
+   ],
+   "source": [
+    "# torchtree should  be installed in the environment where jupyter is running\n",
+    "\n",
+    "!torchtree  $json_outfile"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "t111",
+   "language": "python",
+   "name": "t111"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Notebooks showing examples of using torchtree CLI and API to infer branch lengths and GTR+I parameters with fixed topology.